### PR TITLE
Fix k8s-proxy image to point to coreVersion; bump versions

### DIFF
--- a/bitwarden/Chart.yaml
+++ b/bitwarden/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.40.0"
+appVersion: "1.41.3"
 description: A Helm chart for deploying a Bitwarden instance on Kubernetes
 home: https://bitwarden.com/
 icon: https://raw.githubusercontent.com/bitwarden/brand/master/icons/512x512.png
@@ -13,4 +13,4 @@ name: bitwarden
 sources:
 - https://github.com/bitwarden/server
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/bitwarden/templates/proxy-deployment.yaml
+++ b/bitwarden/templates/proxy-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.proxyContainerName }}
-          image: "{{ .Values.proxyContainerImageRepository }}:{{ .Values.proxyContainerImageTag | default .Values.webVersion }}"
+          image: "{{ .Values.proxyContainerImageRepository }}:{{ .Values.proxyContainerImageTag | default .Values.coreVersion }}"
           imagePullPolicy: {{ .Values.proxyContainerImagePullPolicy }}
           envFrom:
             - configMapRef:

--- a/bitwarden/values.yaml
+++ b/bitwarden/values.yaml
@@ -9,8 +9,8 @@
 ## Core and Web versions to install
 ## - Required
 ##
-coreVersion: "1.40.0"
-webVersion: "2.19.0"
+coreVersion: "1.41.3"
+webVersion: "2.20.2"
 
 ## Labels to apply to all resources
 ## - Optional


### PR DESCRIPTION
This fixes the k8s-proxy image default to point to the `coreVersion` value instead of `webVersion`.
Bumps server version to 1.41.3 and web version to 2.20.2.
Bumps chart version to 0.2.0.