### PR TITLE
Update chart-releaser-action to v1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,9 @@ jobs:
         if: ${{ github.event.inputs.release_mode != 'Dry Run' }}
         env:
           CR_GENERATE_RELEASE_NOTES: true
-          CR_MAKE_RELEASE_LATEST: true
-          CR_SKIP_EXISTING: true
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:
+          mark_as_latest: true
+          skip_existing: true
           skip_packaging: true


### PR DESCRIPTION
This PR updates the `chart-releaser-action` to `v1.6.0` and sets the new inputs instead of using environment variables.