### PR TITLE
Linter workflow - Update lint step to skip version increment check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,4 +46,6 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
+        env:
+          CT_CHECK_VERSION_INCREMENT: false
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
This PR adds an environment variable to skip the version increment check while linting.