### PR TITLE
Pin chart-releaser-action to 1.5.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,11 @@
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchDatasources": ["github-tags"],
+      "matchPackageNames": ["helm/chart-releaser-action"],
+      "allowedVersions": "<=1.5.0"
     }
   ]
 }


### PR DESCRIPTION
This PR pins the `helm/chart-releaser-action` to `v1.5.0` because `v1.6.0` produces errors currently.