### PR TITLE
Feat: Add ability to set custom image registry

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/admin
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.admin" . }}
-        image: "{{ .Values.component.admin.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.admin.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/api
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.api" . }}
-        image: "{{ .Values.component.api.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.api.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ template "bitwarden.attachments" . }}
-        image: "{{ .Values.component.attachments.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.attachments.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/events
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.events" . }}
-        image: "{{ .Values.component.events.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.events.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/helpers.tpl
+++ b/charts/self-host/templates/helpers.tpl
@@ -5,6 +5,10 @@
 {{- "2023.12.0" -}}
 {{- end -}}
 
+{{- define "bitwarden.defaultImageRegistry" -}}
+{{- "registry.hub.docker.com" -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/icons
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.icons" . }}
-        image: "{{ .Values.component.icons.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.icons.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/identity
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.identity" . }}
-        image: "{{ .Values.component.identity.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.identity.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -36,7 +36,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "bitwarden.mssql" . }}
-          image: "{{ .Values.database.image.name }}:{{ .Values.database.image.tag }}"
+          image: "{{ default .Values.general.imageRegistryOverride (default (include "bitwarden.defaultImageRegistry" nil) .Values.database.image.registry) }}/{{ .Values.database.image.name }}:{{ .Values.database.image.tag }}"
           imagePullPolicy: Always
           resources:
 {{ toYaml .Values.database.resources | indent 12 }}

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/notifications
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.notifications" . }}
-        image: "{{ .Values.component.notifications.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.notifications.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/post-delete-hook.yaml
+++ b/charts/self-host/templates/post-delete-hook.yaml
@@ -36,5 +36,5 @@ spec:
           kubectl delete job {{ .Release.Name }}-migrator;
           echo "Done"
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
       restartPolicy: Never

--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -45,7 +45,7 @@ spec:
           echo "Admin Ready!"
         ']
         {{- end }}
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           {{- if .Values.database.enabled }}
           - name: mssql-data
@@ -63,7 +63,7 @@ spec:
               name: "{{ .Values.secrets.secretName }}"
               {{- end }}
               key: globalSettings__sqlServer__connectionString
-        image: "bitwarden/mssqlmigratorutility:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitwarden/mssqlmigratorutility:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         volumeMounts:
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline

--- a/charts/self-host/templates/pre-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/pre-install-db-migrator-job.yaml
@@ -35,7 +35,7 @@ spec:
               name: "{{ .Values.secrets.secretName }}"
               {{- end }}
               key: globalSettings__sqlServer__connectionString
-        image: "bitwarden/mssqlmigratorutility:{{default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitwarden/mssqlmigratorutility:{{default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         volumeMounts:
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline

--- a/charts/self-host/templates/pre-install-job.yaml
+++ b/charts/self-host/templates/pre-install-job.yaml
@@ -39,7 +39,7 @@ spec:
           chmod 777 /bitwarden/identity.pfx;
           echo Done;
         ']
-        image: "docker.io/nginx"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/library/nginx"
         volumeMounts:
         - name: temp
           mountPath: "/bitwarden"
@@ -58,7 +58,7 @@ spec:
 {{- end }}
           echo "Done"
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
         - name: temp
           mountPath: "/bitwarden"

--- a/charts/self-host/templates/pre-install-secret-sql.yaml
+++ b/charts/self-host/templates/pre-install-secret-sql.yaml
@@ -33,7 +33,7 @@ spec:
 
           echo "Done"
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         envFrom:
           - secretRef:
               name: "{{ .Values.secrets.secretName }}"

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -39,14 +39,14 @@ spec:
         args: ['
           mkdir -p /logs/scim
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.scim" . }}
-        image: "{{ .Values.component.scim.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.scim.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -38,14 +38,14 @@ spec:
         args: ['
           mkdir -p /logs/sso
         ']
-        image: "bitnami/kubectl:1.21"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/bitnami/kubectl:1.21"
         volumeMounts:
           - name: applogs
             mountPath: /logs
     {{- end }}
       containers:
       - name: {{ template "bitwarden.sso" . }}
-        image: "{{ .Values.component.sso.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.sso.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ template "bitwarden.web" . }}
-        image: "{{ .Values.component.web.image.name }}:{{ default ( include "bitwarden.webVersionDefault" nil ) .Values.general.webVersionOverride }}"
+        image: "{{ default (include "bitwarden.defaultImageRegistry" nil ) .Values.general.imageRegistryOverride }}/{{ .Values.component.web.image.name }}:{{ default ( include "bitwarden.webVersionDefault" nil ) .Values.general.webVersionOverride }}"
         envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-config-map

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -229,6 +229,9 @@
                 "cloudRegion": {
                     "type": "string",
                     "enum": [ "US", "EU" ]
+                },
+                "imageRegistryOverride": {
+                    "type": "string"
                 }
             }
         },
@@ -2254,6 +2257,9 @@
                     "type": "object",
                     "required": [],
                     "properties": {
+                        "registry": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
                         },

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -82,6 +82,8 @@ general:
   enableCloudCommunication: false
   # Cloud region for sync.  Please see: https://bitwarden.com/help/families-for-enterprise-self-hosted/#step-1-enable-cloud-communication
   cloudRegion: US
+  # Custom image registry. This is useful if you are using a private registry.
+  imageRegistryOverride: ""
 
 # Specify the name of the shared storage class
 # This storage class requires ReadWriteMany.  You will need to provide your own storage class.  Storage classes with automatic volume previsioners are recommended.
@@ -334,7 +336,9 @@ database:
   labels: {}
   # Image name, tag, and pull policy
   image:
-    name: mcr.microsoft.com/mssql/server
+    # The image repository to pull from. Takes precedence over the general.imageRegistryOverride value.
+    registry: mcr.microsoft.com
+    name: mssql/server
     # Tag of the image to use. (Defaults to general.coreVersion)
     tag: 2019-CU17-ubuntu-20.04
   # The container is limited to the resources below.  Adjust for your environment.


### PR DESCRIPTION
Add a global variable to override the image registry to allow the usage of a private registry. 

As my changes include a new registry option for the database image, this seems to be a breaking change. But I don't know if this might be obsolete, because of the issue #70. 