### PR TITLE
Add pin-actions shareable config preset to Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
+    "github>bitwarden/renovate-config:pin-actions",
     ":prConcurrentLimit10",
     ":rebaseStalePrs",
     "schedule:weekends"
@@ -17,11 +18,6 @@
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "matchDatasources": ["github-tags"],
-      "matchPackageNames": ["helm/chart-releaser-action"],
-      "allowedVersions": "<=1.5.0"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a shareable config preset to Renovate for pinning GitHub Actions at certain tags.