### PR TITLE
Update MSSQL image to 2022

### DIFF
--- a/charts/self-host/ci/test-values.yaml
+++ b/charts/self-host/ci/test-values.yaml
@@ -354,7 +354,7 @@ database:
   image:
     name: mcr.microsoft.com/mssql/server
     # Tag of the image to use. (Defaults to general.coreVersion)
-    tag: 2019-CU17-ubuntu-20.04
+    tag: 2022-CU11-ubuntu-22.04
   # The container is limited to the resources below.  Adjust for your environment.
   resources:
     requests:

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -373,7 +373,7 @@ database:
   image:
     name: mcr.microsoft.com/mssql/server
     # Tag of the image to use. (Defaults to general.coreVersion)
-    tag: 2019-CU17-ubuntu-20.04
+    tag: 2022-CU11-ubuntu-22.04
   # The container is limited to the resources below.  Adjust for your environment.
   resources:
     requests:


### PR DESCRIPTION
This PR updates the MSSQL image to 2022 to match our standard Self-Host offering.