### PR TITLE
[PM-6459] Ensure volume is accessible to the mssql user group 10001.

### DIFF
--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -30,6 +30,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        fsGroup: 10001
     {{- if .Values.database.podServiceAccount }}
       serviceAccount: {{ .Values.database.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.database.podServiceAccount | quote }}


### PR DESCRIPTION
Fixes issue [#70 MSSQL pod fail on crashloopBackOff](https://github.com/bitwarden/helm-charts/issues/70)

Basically when I am installing bitwarden on a pod with a PVC attached for storage I can't get past the mssql pod creation because it doesn't have the correct permissions to write to the data volume.   I found the gid of the service `10001` and added it to the  `spec.template.spec.securityContext.fsGroup`

https://github.com/bitwarden/helm-charts/issues/70#issuecomment-1962794964

