### PR TITLE
DEVOPS-1906 - Fix Update Versions workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ env._BRANCH }}
+          ref: main
 
       - name: Get Latest Core Version
         id: get-core

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -116,6 +116,7 @@ jobs:
       needs.setup.outputs.web_version_update == 1
     runs-on: ubuntu-22.04
     needs: setup
+    environment: Production
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -120,22 +120,44 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Log in to Azure - CI subscription
+        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
+        with:
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "github-gpg-private-key,
+            github-gpg-private-key-passphrase,
+            github-pat-bitwarden-devops-bot-repo-scope"
+      
       - name: Checkout Branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ env._BRANCH }}
-
-      - name: Create Update Versions Branch
-        run: |
-          PR_BRANCH=update-versions-$GITHUB_RUN_ID
-          echo "PR_BRANCH=$PR_BRANCH" >> $GITHUB_ENV
-          git switch -c $PR_BRANCH
-          git push -u origin $PR_BRANCH
-
-      - name: Checkout Update Versions Branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+          ref: main
+      
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
         with:
-          ref: ${{ env.PR_BRANCH }}
+          gpg_private_key: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key }}
+          passphrase: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key-passphrase }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set up Git
+        run: |
+          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
+          git config --local user.name "bitwarden-devops-bot"
+
+      - name: Create version branch
+        id: create-branch
+        run: |
+          NAME=version_bump_${{ github.ref_name }}_$(date +"%Y-%m-%d")
+          git switch -c $NAME
+          echo "name=$NAME" >> $GITHUB_OUTPUT
 
       - name: Update Core Version
         env:
@@ -155,22 +177,34 @@ jobs:
         run: "sed -i -e 's/appVersion:.*/appVersion: '$VERSION'/' Chart.yaml"
         working-directory: charts/self-host
 
-      - name: Commit updated files
+      - name: Check if version changed
+        id: version-changed
         run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -m "Updated core and web versions" -a
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes_to_commit=TRUE" >> $GITHUB_OUTPUT
+          else
+            echo "changes_to_commit=FALSE" >> $GITHUB_OUTPUT
+            echo "No changes to commit!";
+          fi
+
+      - name: Commit files
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        run: git commit -m "Updated core and web versions" -a
 
       - name: Push changes
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        env:
+          PR_BRANCH: ${{ steps.create-branch.outputs.name }}
         run: git push -u origin $PR_BRANCH
 
-      - name: Create Update Versions PR
+      - name: Create versions PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          PR_BRANCH: ${{ steps.create-branch.outputs.name }}
           TITLE: "Update core and web versions"
         run: |
-          gh pr create --title "$TITLE" \
+          PR_URL=$(gh pr create --title "$TITLE" \
             --base "$BASE_BRANCH" \
             --head "$PR_BRANCH" \
             --label "automated pr" \
@@ -184,4 +218,19 @@ jobs:
 
               ## Objective
               Automated version updates to core and web versions in charts/self-host/templates/helpers.tpl.
-              Automated version update to appVersion in charts/self-host/Chart.yaml"
+              Automated version update to appVersion in charts/self-host/Chart.yaml")
+          echo "pr_number=${PR_URL##*/}" >> $GITHUB_OUTPUT
+
+      - name: Approve PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
+        run: gh pr review $PR_NUMBER --approve
+
+      - name: Merge PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        env:
+          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
+        run: gh pr merge $PR_NUMBER --squash --auto --delete-branch

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,7 +39,9 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key, github-gpg-private-key-passphrase"
+          secrets: "github-gpg-private-key,
+            github-gpg-private-key-passphrase,
+            github-pat-bitwarden-devops-bot-repo-scope"
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0


### PR DESCRIPTION
This PR updates the `Update Versions` workflow to use the logic we have in other repositories.  The PR is auto approved and set to merge, but due to `CODEOWNERS` it still requires an approval from the DevOps team.  We can look into a fix for this at a later time. I also fixed the secret step in the `Version Bump` workflow.