### PR TITLE
[PM-8962] use dynamic replicas

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.admin.replicas }}
   strategy:
     type: {{ .Values.component.admin.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.api.replicas }}
   strategy:
     type: {{ .Values.component.api.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.attachments.replicas }}
   strategy:
     type: {{ .Values.component.attachments.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.events.replicas }}
   strategy:
     type: {{ .Values.component.events.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.icons.replicas }}
   strategy:
     type: {{ .Values.component.icons.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.identity.replicas }}
   strategy:
     type: {{ .Values.component.identity.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.notifications.replicas }}
   strategy:
     type: {{ .Values.component.notifications.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -40,7 +40,7 @@ spec:
         ']
         {{- else }}
         args: ['
-          while [[ $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "bitwarden.admin" . }} -o jsonpath="{.items[*].status.containerStatuses[*].ready}") != "true" ]]; do sleep 1; done
+          while [[ $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "bitwarden.admin" . }} -o jsonpath="{.items[*].status.containerStatuses[*].ready}" | cut -f1 -d " ") != "true" ]]; do sleep 1; done
 
           echo "Admin Ready!"
         ']

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.scim.replicas }}
   strategy:
     type: {{ .Values.component.scim.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.sso.replicas }}
   strategy:
     type: {{ .Values.component.sso.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.component.web.replicas }}
   strategy:
     type: {{ .Values.component.web.deploymentStrategy | quote }}
   selector:

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -97,6 +97,8 @@ secrets:
 component:
   # The Admin component
   admin:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -117,6 +119,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   api:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -137,6 +141,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   attachments:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -157,6 +163,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   events:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -177,6 +185,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   icons:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -197,6 +207,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   identity:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -217,6 +229,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   notifications:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -237,6 +251,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   scim:
+    # Number of replicas
+    replicas: 1
     # SCIM is disabled by default.  To use this service, enable it below and set an appropriate Ingress path
     enabled: false
     # Additional deployment labels
@@ -259,6 +275,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   sso:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -279,6 +297,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   web:
+    # Number of replicas
+    replicas: 1
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy


### PR DESCRIPTION
This pull request introduces changes to the Bitwarden chart to allow users to configure the number of replicas for each component from the values.yaml file. By default, the number of replicas is set to one for all components. However, the Bitwarden documentation suggests increasing the number of replicas to enhance high availability, which is currently not possible with the existing configuration. This update aims to provide flexibility in setting the replica count per component directly from the values.yaml file.

## Changes Made
Replicas Configuration:
- Introduced new fields in the values.yaml file to specify the number of replicas for each component.
Updated deployment templates to use the specified replica count from the values.yaml file instead of defaulting to one.
Job Adaptation:

- Modified the job configuration to consider only the state of the first container set to true. This adaptation ensures that the job correctly handles the state with the increased number of replicas.