### PR TITLE
Added optional topologySpreadConstraints configuration

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -106,7 +106,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.admin.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -111,7 +111,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -77,7 +77,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.attachments.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -96,7 +96,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-
+      {{- with .Values.component.events.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -96,7 +96,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-
+      {{- with .Values.component.icons.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -113,7 +113,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.identity.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -96,7 +96,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-
+      {{- with .Values.component.notifications.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -112,7 +112,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.scim.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -113,7 +113,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.sso.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -77,7 +77,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-
+      {{- with .Values.component.web.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 12 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -97,6 +97,8 @@ secrets:
 component:
   # The Admin component
   admin:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -117,6 +119,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   api:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -137,6 +141,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   attachments:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -157,6 +163,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   events:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -177,6 +185,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   icons:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -197,6 +207,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   identity:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -217,6 +229,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   notifications:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -237,6 +251,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   scim:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # SCIM is disabled by default.  To use this service, enable it below and set an appropriate Ingress path
     enabled: false
     # Additional deployment labels
@@ -259,6 +275,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   sso:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy
@@ -279,6 +297,8 @@ component:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   web:
+    # Block to configure topologySpreadConstraints if it's necessary
+    topologySpreadConstraints: []
     # Additional deployment labels
     labels: {}
     # Image name, tag, and pull policy


### PR DESCRIPTION
### Description
This pull request introduces optional configuration for topologySpreadConstraints in the Helm chart for better control over pod distribution across nodes.

### Changes Made

- values.yaml: Added topologySpreadConstraints: [] to each component block, allowing users to define topology spread constraints if needed.
- templates/component.yaml: Included logic to render topologySpreadConstraints from values.yaml if specified.

### Benefits
These changes provide the flexibility to specify pod distribution constraints, improving resilience and availability by ensuring pods are evenly spread across failure domains.

### Backwards Compatibility
The default configuration keeps topologySpreadConstraints empty, ensuring no impact on existing deployments that do not require this feature.