### PR TITLE
Added additional SMTP environment variables 

### DIFF
--- a/charts/self-host/templates/pre-install-hook-configmap.yaml
+++ b/charts/self-host/templates/pre-install-hook-configmap.yaml
@@ -36,8 +36,6 @@ data:
   globalSettings__mail__smtp__trustServer: "{{ .Values.general.email.smtpTrustServer }}"
   globalSettings__mail__smtp__sslOverride: "{{ .Values.general.email.smtpSslOverride }}"
   globalSettings__mail__smtp__startTls: "{{ .Values.general.email.smtpStartTls }}"
-
-
 {{- if not (and .Values.volume.logs .Values.volume.logs.enabled) }}
   globalSettings__logDirectory: "/dev/null"
 {{- end }}

--- a/charts/self-host/templates/pre-install-hook-configmap.yaml
+++ b/charts/self-host/templates/pre-install-hook-configmap.yaml
@@ -33,7 +33,7 @@ data:
   globalSettings__mail__smtp__host: "{{ .Values.general.email.smtpHost }}"
   globalSettings__mail__smtp__port: "{{ .Values.general.email.smtpPort }}"
   globalSettings__mail__smtp__ssl: "{{ .Values.general.email.smtpSsl }}"
-  globalSettings__mail__smtp__trustServer=true: "{{ .Values.general.email.smtpTrustServer }}"
+  globalSettings__mail__smtp__trustServer: "{{ .Values.general.email.smtpTrustServer }}"
   globalSettings__mail__smtp__sslOverride: "{{ .Values.general.email.smtpSslOverride }}"
   globalSettings__mail__smtp__startTls: "{{ .Values.general.email.smtpStartTls }}"
 

--- a/charts/self-host/templates/pre-install-hook-configmap.yaml
+++ b/charts/self-host/templates/pre-install-hook-configmap.yaml
@@ -33,6 +33,11 @@ data:
   globalSettings__mail__smtp__host: "{{ .Values.general.email.smtpHost }}"
   globalSettings__mail__smtp__port: "{{ .Values.general.email.smtpPort }}"
   globalSettings__mail__smtp__ssl: "{{ .Values.general.email.smtpSsl }}"
+  globalSettings__mail__smtp__trustServer=true: "{{ .Values.general.email.smtpTrustServer }}"
+  globalSettings__mail__smtp__sslOverride: "{{ .Values.general.email.smtpSslOverride }}"
+  globalSettings__mail__smtp__startTls: "{{ .Values.general.email.smtpStartTls }}"
+
+
 {{- if not (and .Values.volume.logs .Values.volume.logs.enabled) }}
   globalSettings__logDirectory: "/dev/null"
 {{- end }}

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -72,6 +72,13 @@ general:
     smtpPort: "587"
     # Whether your SMTP server uses an encryption protocol, "true" for SSL, "false" for TLS
     smtpSsl: "false"
+    # Specify true to explicitly trust the certificate presented by the SMTP server (not recommended for production).
+    smtpTrustServer: "false"
+    # Specify true to use SSL (not TLS) on port 25.
+    smtpSslOverride: "false"
+    # Specify true to force STARTTLS (Opportunistic TLS).
+    smtpStartTls: "false"
+
   # Custom labels to add throughout the installation
   labels: {}
   # Specifies the access mode for persistent volume claims.  This should not be changed in most cases, and the allowable

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -78,7 +78,6 @@ general:
     smtpSslOverride: "false"
     # Specify true to force STARTTLS (Opportunistic TLS).
     smtpStartTls: "false"
-
   # Custom labels to add throughout the installation
   labels: {}
   # Specifies the access mode for persistent volume claims.  This should not be changed in most cases, and the allowable


### PR DESCRIPTION
Expanded the SMTP global environment variables that can be set in the chart to match those in the documentation:

globalSettings__mail__smtp__trustServer=
globalSettings__mail__smtp__sslOverride=
globalSettings__mail__smtp__startTls=

Updates to the values.yaml file and included these values in the config map. 

Tested deployment and checking these values are present in the config map and also in the running containers