### PR TITLE
changes for push url in air gap env

### DIFF
--- a/charts/self-host/templates/pre-install-hook-configmap.yaml
+++ b/charts/self-host/templates/pre-install-hook-configmap.yaml
@@ -49,9 +49,17 @@ data:
 {{- if eq .Values.general.cloudRegion "EU" }}
   globalSettings__installation__identityUri: "https://identity.bitwarden.eu"
   globalSettings__installation__apiUri: "https://api.bitwarden.eu"
+  {{- if .Values.general.pushRelayBaseUri }}
+  globalSettings__pushRelayBaseUri: "{{ .Values.general.pushRelayBaseUri }}"
+  {{- else }}
   globalSettings__pushRelayBaseUri: "https://push.bitwarden.eu"
+  {{- end }}
 {{- else }}
+  {{- if .Values.general.pushRelayBaseUri }}
+  globalSettings__pushRelayBaseUri: "{{ .Values.general.pushRelayBaseUri }}"
+  {{- else }}
   globalSettings__pushRelayBaseUri: "https://push.bitwarden.com"
+  {{- end }}
 {{- end }}
   adminSettings__admins: {{ .Values.general.admins | quote }}
   LOCAL_UID: "1000"

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -92,6 +92,9 @@ general:
   enableCloudCommunication: false
   # Cloud region for sync.  Please see: https://bitwarden.com/help/families-for-enterprise-self-hosted/#step-1-enable-cloud-communication
   cloudRegion: US
+  # Uncomment but leave as an empty string if deploying offline or in an air-gap environment
+  # pushRelayBaseUri: " "
+
 
 # Specify the name of the shared storage class
 # This storage class requires ReadWriteMany.  You will need to provide your own storage class.  Storage classes with automatic volume previsioners are recommended.


### PR DESCRIPTION
## 🎟️ Tracking

Change is coming from a customer ticket where they state that if a value is set for the push relay URL when in an air gapped environment:
"I managed to resolve problem by updating record in ConfigMap manually, however that doesn’t seem to be a good solution, since it will be changed on the next Helm upgrade.
Without it, all new user enrollments time out with following error:

“
      => SpanId:1a7223b33e81c28a, TraceId:9e2ded3330d58722549d9251a81d93aa, ParentId:0000000000000000 => ConnectionId:0HN9H8O6I0TVA => RequestPath:/identity/connect/token RequestId:0HN9H8O6I0TVA:00000004 => IpAddress:10.42.202.150 UserAgent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 DeviceType:9 Origin:9 ClientVersion:2024.12.0
      Unable to send POST request to https://push.bitwarden.com/push/register because an access token was unable to be obtained
”
 
Would you please provide solution to update following record in ConfigMap through Helm values:

globalSettings__pushRelayBaseUri: "https://push.bitwarden.com/push/register"
>>>
>>>
globalSettings__pushRelayBaseUri: ""

## 📔 Objective

Allow update to the values file to specify a blank string for the globalSettings__pushRelayBaseUri env var

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
