### PR TITLE
Add support for pod security context

### DIFF
--- a/charts/self-host/README.md
+++ b/charts/self-host/README.md
@@ -949,6 +949,7 @@ component:
         memory: "128Mi"
         cpu: "100m"
     securityContext:
+    podSecurityContext:
     podServiceAccount: bitwarden-sa
 ```
 
@@ -1251,6 +1252,7 @@ component:
         memory: "128Mi"
         cpu: "100m"
     securityContext:
+    podSecurityContext:
     podServiceAccount: bitwarden-sa
 ```
 

--- a/charts/self-host/ci/test-values.yaml
+++ b/charts/self-host/ci/test-values.yaml
@@ -373,7 +373,6 @@ database:
     limits:
       memory: "2G"
       cpu: "500m"
-  # This will set the Kubernetes pod security context
   podSecurityContext:
     fsGroup: 10001
 

--- a/charts/self-host/ci/test-values.yaml
+++ b/charts/self-host/ci/test-values.yaml
@@ -373,6 +373,9 @@ database:
     limits:
       memory: "2G"
       cpu: "500m"
+  # This will set the Kubernetes pod security context
+  podSecurityContext:
+    fsGroup: 10001
 
   # The MSSQL volumes for the PVCs
   volume:

--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.admin.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.admin.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.admin.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.admin.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.api.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.api.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.api.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.api.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.attachments.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.attachments.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.attachments.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.attachments.podSecurityContext | indent 8 }}
+    {{- end }}
       containers:
       - name: {{ template "bitwarden.attachments" . }}
         image: "{{ .Values.component.attachments.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.events.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.events.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.events.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.events.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.icons.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.icons.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.icons.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.icons.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.identity.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.identity.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.identity.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.identity.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -34,6 +34,10 @@ spec:
       serviceAccount: {{ .Values.database.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.database.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.database.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.database.podSecurityContext | indent 8 }}
+    {{- end }}
       containers:
         - name: {{ template "bitwarden.mssql" . }}
           image: "{{ .Values.database.image.name }}:{{ .Values.database.image.tag }}"

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.notifications.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.notifications.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.notifications.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.notifications.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccount: {{ .Values.component.scim.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.scim.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.scim.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.scim.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.sso.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.sso.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.sso.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.sso.podSecurityContext | indent 8 }}
+    {{- end }}
     {{- if  .Values.volume.logs.enabled }}
       initContainers:
       - name: create-mount-subdir

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -29,6 +29,10 @@ spec:
       serviceAccount: {{ .Values.component.web.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.web.podServiceAccount | quote }}
     {{- end }}
+    {{- if .Values.component.web.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.component.web.podSecurityContext | indent 8 }}
+    {{- end }}
       containers:
       - name: {{ template "bitwarden.web" . }}
         image: "{{ .Values.component.web.image.name }}:{{ default ( include "bitwarden.webVersionDefault" nil ) .Values.general.webVersionOverride }}"

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -315,6 +315,13 @@
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
                         },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
+                        },
                         "securityContext": {
                             "type": [
                                 "object",
@@ -504,6 +511,13 @@
                         "deploymentStrategy": {
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
+                        },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
                         },
                         "securityContext": {
                             "type": [
@@ -695,6 +709,13 @@
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
                         },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
+                        },
                         "securityContext": {
                             "type": [
                                 "object",
@@ -884,6 +905,13 @@
                         "deploymentStrategy": {
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
+                        },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
                         },
                         "securityContext": {
                             "type": [
@@ -1075,6 +1103,13 @@
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
                         },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
+                        },
                         "securityContext": {
                             "type": [
                                 "object",
@@ -1265,6 +1300,13 @@
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
                         },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
+                        },
                         "securityContext": {
                             "type": [
                                 "object",
@@ -1454,6 +1496,13 @@
                         "deploymentStrategy": {
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
+                        },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
                         },
                         "securityContext": {
                             "type": [
@@ -1648,6 +1697,13 @@
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
                         },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
+                        },
                         "securityContext": {
                             "type": [
                                 "object",
@@ -1837,6 +1893,13 @@
                         "deploymentStrategy": {
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
+                        },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
                         },
                         "securityContext": {
                             "type": [
@@ -2029,6 +2092,13 @@
                         "deploymentStrategy": {
                             "type": "string",
                             "enum": ["RollingUpdate", "Recreate"]
+                        },
+                        "podSecurityContext": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "required": []
                         },
                         "securityContext": {
                             "type": [
@@ -2415,6 +2485,13 @@
                 "updateStrategy": {
                     "type": "string",
                     "enum": ["RollingUpdate", "OnDelete"]
+                },
+                "podSecurityContext": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": []
                 },
                 "securityContext": {
                     "type": [

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -126,6 +126,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   api:
@@ -146,6 +148,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   attachments:
@@ -166,6 +170,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   events:
@@ -186,6 +192,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   icons:
@@ -206,6 +214,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   identity:
@@ -226,6 +236,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   notifications:
@@ -246,6 +258,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   scim:
@@ -268,6 +282,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   sso:
@@ -288,6 +304,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
   web:
@@ -308,6 +326,8 @@ component:
     deploymentStrategy: RollingUpdate
     # This will set the Kubernetes container security context
     securityContext:
+    # This will set the Kubernetes pod security context
+    podSecurityContext:
     # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
     podServiceAccount:
 # Images used for jobs and init containers
@@ -434,6 +454,8 @@ database:
   updateStrategy: OnDelete
   # This will set the Kubernetes container security context
   securityContext:
+  # This will set the Kubernetes pod security context (including fsGroup)
+  podSecurityContext:
   # Run the pod under a service account you create.  This is especially useful for OpenShift deployments
   podServiceAccount:
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds support for supplying the chart with pod security context, such as `fsGroup` for the database and other supported contexts https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
