### PR TITLE
added onlyMappedSecrets

### DIFF
--- a/charts/sm-operator/templates/bitwardensecret-crd.yaml
+++ b/charts/sm-operator/templates/bitwardensecret-crd.yaml
@@ -68,6 +68,13 @@ spec:
                   - secretKeyName
                   type: object
                 type: array
+              onlyMappedSecrets:
+                default: true
+                description: OnlyMappedSecrets, when true, restricts the Kubernetes
+                  Secret to only include secrets specified in SecretMap. When false
+                  or unset, all secrets accessible by the machine account are included,
+                  with SecretMap applied for renaming. Defaults to true.
+                type: boolean
               organizationId:
                 description: The organization ID for your organization
                 type: string


### PR DESCRIPTION
## 🎟️ Tracking

[Creating a BitwardenSecret loads all secrets in project into the destination secret](https://github.com/bitwarden/sm-kubernetes/issues/60)

## 📔 Objective

Add a new parameter to control if the secrets map is used to constrain what secrets get mapped across into the deployment. 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
