### PR TITLE
BRE-976: Add DOTNET_BUNDLE_EXTRACT_BASE_DIR env variable with `emptyDir`.

### DIFF
--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -76,7 +76,7 @@ spec:
         image: "{{ .Values.supportComponents.dbMigrator.image.name }}:{{ default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         volumeMounts:
         - name: migrator-extract-dir
-          mountPath: /migrator
+          mountPath: "/migrator"
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"

--- a/charts/self-host/templates/pre-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/pre-install-db-migrator-job.yaml
@@ -48,7 +48,7 @@ spec:
         image: "{{ .Values.supportComponents.dbMigrator.image.name }}:{{default ( include "bitwarden.coreVersionDefault" nil ) .Values.general.coreVersionOverride }}"
         volumeMounts:
         - name: migrator-extract-dir
-          mountPath: /migrator
+          mountPath: "/migrator"
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Add a path with `emptyDir` for MSSQL migration jobs for .NET bundle extraction during runtime, this allows the migration jobs to run in a strict read-only file system environment.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
