### PR TITLE
BRE-896 - [Self-Host]: Update CD workflows for SemVer

### DIFF
--- a/.github/workflows/version-bump-self-host.yml
+++ b/.github/workflows/version-bump-self-host.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   bump_version:
     name: Bump Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: Production
     permissions:
       contents: write
@@ -19,16 +19,9 @@ jobs:
       id-token: write
     steps:
       - name: Validate version input
-        if: ${{ inputs.version_number_override != '' }}
         uses: bitwarden/gh-actions/version-check@main
         with:
-          version: ${{ inputs.version_number_override }}
-
-      - name: Checkout Branch
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: main
-          persist-credentials: true
+          version: ${{ inputs.version_number }}
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -57,13 +50,16 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: true
           ref: main
           token: ${{ steps.app-token.outputs.token }}
         
       - name: Set up Git client
+        id: create-branch
         run: |
           git config --global user.name 'bw-ghapp[bot]'
           git config --global user.email '178206702+bw-ghapp[bot]@users.noreply.github.com'
+
           NAME=version_bump_${GITHUB_REF_NAME}_$(date +"%Y-%m-%d")
           git switch -c "$NAME"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
@@ -75,7 +71,6 @@ jobs:
           echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Verify input version
-        if: ${{ inputs.version_number != '' }}
         env:
           CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
           NEW_VERSION: ${{ inputs.version_number }}
@@ -94,26 +89,11 @@ jobs:
             exit 1
           fi
 
-      - name: Bump Chart Version - Version Override
-        id: bump-version-override
+      - name: Bump Chart Version
         uses: bitwarden/gh-actions/version-bump@main
         with:
           file_path: "charts/self-host/Chart.yaml"
           version: ${{ inputs.version_number }}
-
-      - name: Set final version output
-        id: set-final-version-output
-        env:
-          _BUMP_VERSION_OVERRIDE_OUTCOME: ${{ steps.bump-version-override.outcome }}
-          _INPUT_VERSION_NUMBER_OVERRIDE: ${{ inputs.version_number_override }}
-          _BUMP_VERSION_AUTOMATIC_OUTCOME: ${{ steps.bump-version-automatic.outcome }}
-          _CALCULATE_NEXT_VERSION: ${{ steps.calculate-next-version.outputs.version }}
-        run: |
-          if [[ "${_BUMP_VERSION_OVERRIDE_OUTCOME}" == "success" ]]; then
-            echo "version=${_INPUT_VERSION_NUMBER_OVERRIDE}" >> "$GITHUB_OUTPUT"
-          elif [[ "${_BUMP_VERSION_AUTOMATIC_OUTCOME}" == "success" ]]; then
-            echo "version=${_CALCULATE_NEXT_VERSION}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Check if version changed
         id: version-changed
@@ -128,8 +108,8 @@ jobs:
       - name: Commit files
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
-          _FINAL_VERSION: ${{ steps.set-final-version-output.outputs.version }}
-        run: git commit -m "Bumped version to ${_FINAL_VERSION}" -a
+          VERSION: ${{ inputs.version_number }}
+        run: git commit -m "Bumped version to ${VERSION}" -a
 
       - name: Push changes
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
@@ -141,10 +121,10 @@ jobs:
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         id: create-pr
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BRANCH: ${{ steps.create-branch.outputs.name }}
-          TITLE: "Bump version to ${{ steps.set-final-version-output.outputs.version }}"
-          _FINAL_VERSION: ${{ steps.set-final-version-output.outputs.version }}
+          TITLE: "Bump version to ${{ inputs.version_number }}"
+          VERSION: ${{ inputs.version_number }}
         run: |
           PR_URL=$(gh pr create --title "$TITLE" \
             --base "main" \
@@ -160,7 +140,7 @@ jobs:
               - [X] Other
 
               ## Objective
-              Automated version bump to ${_FINAL_VERSION}")
+              Automated version bump to ${VERSION}")
           echo "pr_number=${PR_URL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Approve PR
@@ -173,6 +153,6 @@ jobs:
       - name: Merge PR
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         run: gh pr merge "$PR_NUMBER" --squash --auto --delete-branch


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/BRE-896
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Sets up the version bump workflow to support SemVer. There were a lot of items I needed to refactor since it was using CalVer supported external actions. 

The main change is that the version input is now required, this will be temporary until we move towards label versions, similar to the https://github.com/bitwarden/workflow-linter project.

Based on the testing done in the branch https://github.com/bitwarden/helm-charts/commits/BRE-896-test/ I was able to get a test run here https://github.com/bitwarden/helm-charts/actions/runs/17658147352.

This resulted in a branch with the changes (PR was skipped during testing).
https://github.com/bitwarden/helm-charts/commits/version_bump_BRE-896-test_2025-09-11/

** Merge PR post SemVer migration on November 13th**
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
