### PR TITLE
[PM-31743] Remove unused service account section from _helpers.tpl

### DIFF
--- a/charts/sm-operator/templates/_helpers.tpl
+++ b/charts/sm-operator/templates/_helpers.tpl
@@ -64,17 +64,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
-*/}}
-{{- define "sm-operator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "sm-operator.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
-
-{{/*
 Name of the keys secret
 */}}
 {{- define "sm-operator.configmap" -}}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31743](https://bitwarden.atlassian.net/browse/PM-31743)

## 📔 Objective

Remove unused section in `_helpers.tpl` used to configure the service account name, which references keys no longer present in `values.yml`, and which has no effect on the rendered chart.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31743]: https://bitwarden.atlassian.net/browse/PM-31743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ