### PR TITLE
Add URLRewrite filters to HTTPRoute to match Ingress prefix-strippig

### DIFF
--- a/charts/self-host/templates/httproute.yaml
+++ b/charts/self-host/templates/httproute.yaml
@@ -38,6 +38,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.attachments.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.attachments" . }}
           port: 5000
@@ -45,6 +51,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.api.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.api" . }}
           port: 5000
@@ -52,6 +64,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.icons.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.icons" . }}
           port: 5000
@@ -59,6 +77,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.notifications.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.notifications" . }}
           port: 5000
@@ -66,6 +90,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.events.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.events" . }}
           port: 5000
@@ -74,6 +104,12 @@ spec:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.scim.path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: {{ template "bitwarden.scim" . }}
           port: 5000

--- a/charts/self-host/tests/httproute_test.yaml
+++ b/charts/self-host/tests/httproute_test.yaml
@@ -124,6 +124,78 @@ tests:
           path: metadata.labels.custom-label
           value: custom-value
 
+  - it: should apply URLRewrite filter to api rule to strip path prefix
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[1].filters[0].type
+          value: URLRewrite
+      - equal:
+          path: spec.rules[1].filters[0].urlRewrite.path.type
+          value: ReplacePrefixMatch
+      - equal:
+          path: spec.rules[1].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+
+  - it: should apply URLRewrite filter to attachments, icons, notifications, and events rules
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+      - equal:
+          path: spec.rules[2].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+      - equal:
+          path: spec.rules[3].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+      - equal:
+          path: spec.rules[4].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+
+  - it: should not apply filters to sso, identity, admin, or web rules
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+    asserts:
+      - notExists:
+          path: spec.rules[5].filters
+      - notExists:
+          path: spec.rules[6].filters
+      - notExists:
+          path: spec.rules[7].filters
+      - notExists:
+          path: spec.rules[8].filters
+
+  - it: should apply URLRewrite filter to scim rule when SCIM is enabled
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+      component.scim.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[5].filters[0].type
+          value: URLRewrite
+      - equal:
+          path: spec.rules[5].filters[0].urlRewrite.path.replacePrefixMatch
+          value: /
+
   - it: should respect custom paths
     template: templates/httproute.yaml
     set:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SHOT-146?atlOrigin=eyJpIjoiYzdhNjZiYTNlZjRiNDg1MTk3ZWRiMTUwYWIxNTdhMzciLCJwIjoiaiJ9

## 📔 Objective

When users opt into Gateway API (general.gateway.enabled: true), the rendered HTTPRoute sends the full request path (including the prefix) to the upstream Bitwarden services. The legacy Ingress template stripped the prefix for api, attachments, icons, notifications, events, and scim via the regex pattern /<prefix>/(.*) paired with nginx rewrite-target: /$1. 

The HTTPRoute template has no equivalent, so those backends 404 every request (verified locally — /api/version returns 404 via Gateway, 200 via the legacy Ingress).
