### PR TITLE
Set no value as default for external dependency tags

### DIFF
--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -3591,7 +3591,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "3.5.5",
+                  "default": "",
                   "required": [],
                   "title": "tag",
                   "type": [
@@ -3659,7 +3659,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "1.35.3",
+                  "default": "",
                   "required": [],
                   "title": "tag",
                   "type": [

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -758,6 +758,7 @@ supportComponents:
       repository: alpine/openssl
       # @schema
       # type: [string, number]
+      # default: ""
       # @schema
       tag: 3.5.5
   kubectl:
@@ -769,6 +770,7 @@ supportComponents:
       repository: alpine/kubectl
       # @schema
       # type: [string, number]
+      # default: ""
       # @schema
       tag: 1.35.3
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Renovate PRs bump the tag version for dependencies ([1](https://github.com/bitwarden/helm-charts/pull/497), [2](https://github.com/bitwarden/helm-charts/pull/491)) which was tracked in the schema, this removes the default value from the schema by annotating the values file. This way Renovate can bump the tag version for external dependencies without generating schema.

The schema is used for validation and IDE-hinting, the tag values for external dependencies don't need to have a default for this.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
