### PR TITLE
[FIX] Add token generation to workflow

### DIFF
--- a/.github/workflows/version-bump-self-host.yml
+++ b/.github/workflows/version-bump-self-host.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     steps:
       - name: Validate version input
@@ -23,11 +24,36 @@ jobs:
           version: ${{ inputs.version_number }}
           validation_type: semver
 
+      - name: Log in to Azure
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "gh-org-bitwarden"
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Log out from Azure
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-KEY }}
+
       - name: Checkout Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
         
       - name: Set up Git client
         id: create-branch
@@ -96,7 +122,7 @@ jobs:
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         id: create-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BRANCH: ${{ steps.create-branch.outputs.name }}
           TITLE: "Bump version to ${{ inputs.version_number }}"
           VERSION: ${{ inputs.version_number }}


### PR DESCRIPTION
## 📔 Objective
Repo changes now require app token for pushing branches. Added token generation steps back into workflow.