### PR TITLE
fix typo on refresh token var

### DIFF
--- a/charts/self-host/templates/pre-install-hook-configmap.yaml
+++ b/charts/self-host/templates/pre-install-hook-configmap.yaml
@@ -44,7 +44,7 @@ data:
   globalSettings__logDirectory: "/dev/null"
 {{- end }}
 {{- if (.Values.general.refreshTokens.enabled) }}
-  globalSettings__IdentityServer__ApplyAbsoluteRefreshTokenOnRefreshToken: {{ .Values.general.refreshTokens.applyAbsoluteRefreshTokenOnRefreshToken | default "false" | quote }}
+  globalSettings__IdentityServer__ApplyAbsoluteExpirationOnRefreshToken: {{ .Values.general.refreshTokens.applyAbsoluteExpirationOnRefreshToken | default "false" | quote }}
   globalSettings__IdentityServer__AbsoluteRefreshTokenLifetimeSeconds: {{
   .Values.general.refreshTokens.absoluteRefreshTokenLifetimeSeconds | default "0" | quote }}
   globalSettings__IdentityServer__SlidingRefreshTokenLifetimeSeconds: {{

--- a/charts/self-host/tests/configmap_test.yaml
+++ b/charts/self-host/tests/configmap_test.yaml
@@ -23,3 +23,42 @@ tests:
       - isNull:
           path: data.globalSettings__knownNetworks
         documentIndex: 0
+
+  - it: should render ApplyAbsoluteExpirationOnRefreshToken env var when refreshTokens enabled
+    template: templates/pre-install-hook-configmap.yaml
+    set:
+      general.domain: "example.com"
+      general.refreshTokens.enabled: true
+    asserts:
+      - equal:
+          path: data.globalSettings__IdentityServer__ApplyAbsoluteExpirationOnRefreshToken
+          value: "true"
+        documentIndex: 0
+      - isNull:
+          path: data.globalSettings__IdentityServer__ApplyAbsoluteRefreshTokenOnRefreshToken
+        documentIndex: 0
+
+  - it: should honor explicit applyAbsoluteExpirationOnRefreshToken override
+    template: templates/pre-install-hook-configmap.yaml
+    set:
+      general.domain: "example.com"
+      general.refreshTokens.enabled: true
+      general.refreshTokens.applyAbsoluteExpirationOnRefreshToken: "false"
+    asserts:
+      - equal:
+          path: data.globalSettings__IdentityServer__ApplyAbsoluteExpirationOnRefreshToken
+          value: "false"
+        documentIndex: 0
+
+  - it: should not render refresh token env vars when refreshTokens disabled
+    template: templates/pre-install-hook-configmap.yaml
+    set:
+      general.domain: "example.com"
+      general.refreshTokens.enabled: false
+    asserts:
+      - isNull:
+          path: data.globalSettings__IdentityServer__ApplyAbsoluteExpirationOnRefreshToken
+        documentIndex: 0
+      - isNull:
+          path: data.globalSettings__IdentityServer__AbsoluteRefreshTokenLifetimeSeconds
+        documentIndex: 0

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -3129,9 +3129,9 @@
               "title": "absoluteRefreshTokenLifetimeSeconds",
               "type": "string"
             },
-            "applyAbsoluteRefreshTokenOnRefreshToken": {
+            "applyAbsoluteExpirationOnRefreshToken": {
               "default": "true",
-              "title": "applyAbsoluteRefreshTokenOnRefreshToken",
+              "title": "applyAbsoluteExpirationOnRefreshToken",
               "type": "string"
             },
             "enabled": {

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -173,7 +173,7 @@ general:
   refreshTokens:
     # Set to true to enable refresh tokens.  Recommended for production environments.
     enabled: false
-    applyAbsoluteRefreshTokenOnRefreshToken: "true"
+    applyAbsoluteExpirationOnRefreshToken: "true"
     absoluteRefreshTokenLifetimeSeconds: "30"
     slidingRefreshTokenLifetimeSeconds: ""
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SHOT-153

## 📔 Objective

The chart was sending globalSettings__IdentityServer__ApplyAbsoluteRefreshTokenOnRefreshToken but Bitwarden server only reads ApplyAbsoluteExpirationOnRefreshToken. 

The misnamed env var was silently ignored since PR #386, so every user with refreshTokens.enabled: true has been getting the server default (sliding expiration) instead of the chart's stated "true" (absolute expiration).

