### PR TITLE
Allow setting affinity for more fine-grained node scheduling

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -43,6 +43,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.admin.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.admin.affinity }}
+        {{ toYaml .Values.component.admin.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.admin.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.admin.nodeSelector }}

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -43,6 +43,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.api.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.api.affinity }}
+        {{ toYaml .Values.component.api.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.api.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.api.nodeSelector }}

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -42,6 +42,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.attachments.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.attachments.affinity }}
+        {{ toYaml .Values.component.attachments.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.attachments.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.attachments.nodeSelector }}

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -43,6 +43,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.events.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.events.affinity }}
+        {{ toYaml .Values.component.events.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.events.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.events.nodeSelector }}

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -42,6 +42,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.icons.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.icons.affinity }}
+        {{ toYaml .Values.component.icons.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.icons.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.icons.nodeSelector }}

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -43,6 +43,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.identity.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.identity.affinity }}
+        {{ toYaml .Values.component.identity.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.identity.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.identity.nodeSelector }}

--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -50,6 +50,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -42,6 +42,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.notifications.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.notifications.affinity }}
+        {{ toYaml .Values.component.notifications.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.notifications.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.notifications.nodeSelector }}

--- a/charts/self-host/templates/post-delete-hook.yaml
+++ b/charts/self-host/templates/post-delete-hook.yaml
@@ -38,6 +38,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -40,6 +40,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/pre-install-db-migrator-job.yaml
@@ -44,6 +44,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-job.yaml
+++ b/charts/self-host/templates/pre-install-job.yaml
@@ -50,6 +50,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-secret-sql.yaml
+++ b/charts/self-host/templates/pre-install-secret-sql.yaml
@@ -40,6 +40,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.general.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -44,6 +44,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.scim.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.scim.affinity }}
+        {{ toYaml .Values.component.scim.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.scim.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.scim.nodeSelector }}

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -43,6 +43,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.sso.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.sso.affinity }}
+        {{ toYaml .Values.component.sso.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.sso.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.sso.nodeSelector }}

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -42,6 +42,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.component.web.affinity .Values.general.affinity }}
+      affinity:
+        {{- if .Values.component.web.affinity }}
+        {{ toYaml .Values.component.web.affinity | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.affinity | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if or .Values.component.web.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.web.nodeSelector }}

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -7,6 +7,12 @@
         "admin": {
           "description": "The Admin component",
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -244,6 +250,12 @@
         },
         "api": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -501,6 +513,12 @@
         },
         "attachments": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -732,6 +750,12 @@
         },
         "events": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -970,6 +994,12 @@
         },
         "icons": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -1201,6 +1231,12 @@
         },
         "identity": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -1458,6 +1494,12 @@
         },
         "notifications": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -1689,6 +1731,12 @@
         },
         "scim": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -1862,6 +1910,12 @@
         },
         "sso": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -2114,6 +2168,12 @@
         },
         "web": {
           "properties": {
+            "affinity": {
+              "description": "Optionally place deployment on specifc nodes",
+              "required": [],
+              "title": "affinity",
+              "type": "object"
+            },
             "annotations": {
               "description": "Additional deployment annotations",
               "required": [],
@@ -2352,6 +2412,12 @@
     "database": {
       "description": "\nConfigure MSSQL Database Deployment\nThis section is only used when general.databaseProvider is \"mssql\"\nFor PostgreSQL deployments, users must bring their own\nPostgreSQL database and provide the connection string via secrets.secretName or one of the other configuration providers.\n",
       "properties": {
+        "affinity": {
+          "description": "Optionally place deployment on specifc nodes",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
         "annotations": {
           "description": "Annotations to add to the MSSQL deployment",
           "required": [],
@@ -2389,7 +2455,6 @@
           "type": "object"
         },
         "nodeSelector": {
-          "description": "Optionally place deployment on specifc nodes",
           "required": [],
           "title": "nodeSelector",
           "type": "object"
@@ -2575,6 +2640,12 @@
           "description": "Comma-separated list of email addresses for Admin users",
           "title": "admins",
           "type": "string"
+        },
+        "affinity": {
+          "description": "affinity, nodeSelector and tolerations defined here will apply to all templates in the Helm chart. They can be individually overridden",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
         },
         "annotations": {
           "description": "Custom annotations to add throughout the installation",
@@ -3112,7 +3183,6 @@
           "type": "object"
         },
         "nodeSelector": {
-          "description": "nodeSelector and tolerations defined here will apply to all templates in the Helm chart. They can be individually overridden",
           "required": [],
           "title": "nodeSelector",
           "type": "object"

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -144,7 +144,8 @@ general:
   podLabels: {}
   # Additional default pod annotations
   podAnnotations: {}
-  # nodeSelector and tolerations defined here will apply to all templates in the Helm chart. They can be individually overridden
+  # affinity, nodeSelector and tolerations defined here will apply to all templates in the Helm chart. They can be individually overridden
+  affinity: {}
   nodeSelector: {}
   tolerations: []
   # Image pull secret(s) applied to all pods. Secret(s) must already exist in the release namespace.
@@ -227,6 +228,8 @@ component:
     # Additional pod annotations
     podAnnotations: {}
     # Optionally place deployment on specifc nodes
+    affinity: {}
+    # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
     tolerations: []
@@ -284,6 +287,8 @@ component:
     podLabels: {}
     # Additional pod annotations
     podAnnotations: {}
+    # Optionally place deployment on specifc nodes
+    affinity: {}
     # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
@@ -347,6 +352,8 @@ component:
     # Additional pod annotations
     podAnnotations: {}
     # Optionally place deployment on specifc nodes
+    affinity: {}
+    # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
     tolerations: []
@@ -401,6 +408,8 @@ component:
     podLabels: {}
     # Additional pod annotations
     podAnnotations: {}
+    # Optionally place deployment on specifc nodes
+    affinity: {}
     # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
@@ -461,6 +470,8 @@ component:
     # Additional pod annotations
     podAnnotations: {}
     # Optionally place deployment on specifc nodes
+    affinity: {}
+    # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
     tolerations: []
@@ -515,6 +526,8 @@ component:
     podLabels: {}
     # Additional pod annotations
     podAnnotations: {}
+    # Optionally place deployment on specifc nodes
+    affinity: {}
     # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
@@ -578,6 +591,8 @@ component:
     # Additional pod annotations
     podAnnotations: {}
     # Optionally place deployment on specifc nodes
+    affinity: {}
+    # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
     tolerations: []
@@ -635,6 +650,8 @@ component:
     # Additional pod annotations
     podAnnotations: {}
     # Optionally place deployment on specifc nodes
+    affinity: {}
+    # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
     tolerations: []
@@ -678,6 +695,8 @@ component:
     podLabels: {}
     # Additional pod annotations
     podAnnotations: {}
+    # Optionally place deployment on specifc nodes
+    affinity: {}
     # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
@@ -739,6 +758,8 @@ component:
     podLabels: {}
     # Additional pod annotations
     podAnnotations: {}
+    # Optionally place deployment on specifc nodes
+    affinity: {}
     # Optionally place deployment on specifc nodes
     nodeSelector: {}
     # Optionally add taint tolerations
@@ -973,6 +994,7 @@ database:
   # Additional annotations to the MSSQL pod
   podAnnotations: {}
   # Optionally place deployment on specifc nodes
+  affinity: {}
   nodeSelector: {}
   # Optionally add taint tolerations
   tolerations: []


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

None.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Allows to schedule pods in a more fine-grained way than just a simple "nodeSelector" term.

This is especially useful for environment where RWX PVCs are not supported.
