### PR TITLE
Add imagePullSecrets for all deployments

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -39,6 +39,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.admin.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.admin.nodeSelector }}

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -39,6 +39,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.api.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.api.nodeSelector }}

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -38,6 +38,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.attachments.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.attachments.nodeSelector }}

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -39,6 +39,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.events.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.events.nodeSelector }}

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -38,6 +38,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.icons.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.icons.nodeSelector }}

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -39,6 +39,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.identity.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.identity.nodeSelector }}

--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -46,6 +46,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -38,6 +38,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.notifications.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.notifications.nodeSelector }}

--- a/charts/self-host/templates/post-delete-hook.yaml
+++ b/charts/self-host/templates/post-delete-hook.yaml
@@ -34,6 +34,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -36,6 +36,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/pre-install-db-migrator-job.yaml
@@ -40,6 +40,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-job.yaml
+++ b/charts/self-host/templates/pre-install-job.yaml
@@ -46,6 +46,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/pre-install-secret-sql.yaml
+++ b/charts/self-host/templates/pre-install-secret-sql.yaml
@@ -36,6 +36,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -40,6 +40,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.scim.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.scim.nodeSelector }}

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -39,6 +39,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.sso.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.sso.nodeSelector }}

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -38,6 +38,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.general.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.component.web.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- if .Values.component.web.nodeSelector }}

--- a/charts/self-host/tests/image_pull_secrets_test.yaml
+++ b/charts/self-host/tests/image_pull_secrets_test.yaml
@@ -1,0 +1,227 @@
+suite: test general.imagePullSecrets propagation
+templates:
+  - templates/helpers.tpl
+  - templates/admin.yaml
+  - templates/api.yaml
+  - templates/attachments.yaml
+  - templates/events.yaml
+  - templates/icons.yaml
+  - templates/identity.yaml
+  - templates/notifications.yaml
+  - templates/scim.yaml
+  - templates/sso.yaml
+  - templates/web.yaml
+  - templates/mssql.yaml
+  - templates/pre-install-job.yaml
+  - templates/pre-install-db-migrator-job.yaml
+  - templates/post-install-db-migrator-job.yaml
+  - templates/post-delete-hook.yaml
+
+tests:
+  - it: api - should not render imagePullSecrets when unset
+    template: templates/api.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+        documentIndex: 0
+
+  - it: api - should render imagePullSecrets when set
+    template: templates/api.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: api - should render multiple imagePullSecrets
+    template: templates/api.yaml
+    set:
+      general.imagePullSecrets:
+        - name: primary-registry
+        - name: secondary-registry
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: primary-registry
+            - name: secondary-registry
+        documentIndex: 0
+
+  - it: admin - should render imagePullSecrets when set
+    template: templates/admin.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: attachments - should render imagePullSecrets when set
+    template: templates/attachments.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: events - should render imagePullSecrets when set
+    template: templates/events.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: icons - should render imagePullSecrets when set
+    template: templates/icons.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: identity - should render imagePullSecrets when set
+    template: templates/identity.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: notifications - should render imagePullSecrets when set
+    template: templates/notifications.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: scim - should render imagePullSecrets when set
+    template: templates/scim.yaml
+    set:
+      component.scim.enabled: true
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: sso - should render imagePullSecrets when set
+    template: templates/sso.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: web - should render imagePullSecrets when set
+    template: templates/web.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: mssql - should not render imagePullSecrets when unset
+    template: templates/mssql.yaml
+    set:
+      database.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+        documentIndex: 0
+
+  - it: mssql - should render imagePullSecrets when set
+    template: templates/mssql.yaml
+    set:
+      database.enabled: true
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+        documentIndex: 0
+
+  - it: pre-install-job - should render imagePullSecrets when set
+    template: templates/pre-install-job.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+
+  - it: pre-install-db-migrator-job - should render imagePullSecrets when set
+    template: templates/pre-install-db-migrator-job.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+
+  - it: post-install-db-migrator-job - should render imagePullSecrets when set
+    template: templates/post-install-db-migrator-job.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+
+  - it: post-delete-hook - should render imagePullSecrets when set
+    template: templates/post-delete-hook.yaml
+    set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds

--- a/charts/self-host/tests/image_pull_secrets_test.yaml
+++ b/charts/self-host/tests/image_pull_secrets_test.yaml
@@ -14,6 +14,7 @@ templates:
   - templates/mssql.yaml
   - templates/pre-install-job.yaml
   - templates/pre-install-db-migrator-job.yaml
+  - templates/pre-install-secret-sql.yaml
   - templates/post-install-db-migrator-job.yaml
   - templates/post-delete-hook.yaml
 
@@ -196,6 +197,18 @@ tests:
   - it: pre-install-db-migrator-job - should render imagePullSecrets when set
     template: templates/pre-install-db-migrator-job.yaml
     set:
+      general.imagePullSecrets:
+        - name: my-registry-creds
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-registry-creds
+
+  - it: pre-install-secret-sql - should render imagePullSecrets when set
+    template: templates/pre-install-secret-sql.yaml
+    set:
+      database.enabled: true
       general.imagePullSecrets:
         - name: my-registry-creds
     asserts:

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -2862,6 +2862,14 @@
           "title": "gateway",
           "type": "object"
         },
+        "imagePullSecrets": {
+          "description": "Image pull secret(s) applied to all pods. Secret(s) must already exist in the release namespace.",
+          "items": {
+            "required": []
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
         "ingress": {
           "properties": {
             "annotations": {

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -144,6 +144,8 @@ general:
   # nodeSelector and tolerations defined here will apply to all templates in the Helm chart. They can be individually overridden
   nodeSelector: {}
   tolerations: []
+  # Image pull secret(s) applied to all pods. Secret(s) must already exist in the release namespace.
+  imagePullSecrets: []
   # Specifies the access mode for persistent volume claims.  This should not be changed in most cases, and the allowable
   # values are only ReadWriteMany and ReadWriteOnce.  Please read https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
   # to better understand these options before changing this value.


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SHOT-162
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds the ability for users to provide imagePullSecrets via `general.imagePullSecrets`, a list of secrets is acceptable.

This was tested in a KIND cluster using a private registry, by deploying the manifest

```
apiVersion: v1
kind: Namespace
metadata:
  name: private-registry
---
apiVersion: v1
kind: Secret
metadata:
  name: registry-htpasswd
  namespace: private-registry
type: Opaque
data:
  htpasswd: <base64 of `htpasswd -Bbn testuser testpass`> # Set password here
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: private-registry
  namespace: private-registry
spec:
  replicas: 1
  selector:
    matchLabels: { app: private-registry }
  template:
    metadata:
      labels: { app: private-registry }
    spec:
      hostNetwork: true
      containers:
      - name: registry
        image: registry:2
        env:
        - { name: REGISTRY_AUTH, value: htpasswd }
        - { name: REGISTRY_AUTH_HTPASSWD_REALM, value: local }
        - { name: REGISTRY_AUTH_HTPASSWD_PATH, value: /auth/htpasswd }
        - { name: REGISTRY_HTTP_ADDR, value: ":5555" }
        ports:
        - { containerPort: 5555, hostPort: 5555 }
        volumeMounts:
        - { name: htpasswd, mountPath: /auth }
      volumes:
      - name: htpasswd
        secret:
          secretName: registry-htpasswd
```

Then create a dockerconfigjson secret
```
kubectl -n pullsecret-test create secret docker-registry registry-creds \
    --docker-server=127.0.0.1:5555 \
    --docker-username=testuser \
    --docker-password=testpass
```

Push an image into the registry
```
  kubectl -n private-registry port-forward deployment/private-registry 5555:5555 &
  echo testpass | docker login 127.0.0.1:5555 -u testuser --password-stdin
  docker pull ghcr.io/bitwarden/api:2026.4.1
  docker tag ghcr.io/bitwarden/api:2026.4.1 127.0.0.1:5555/api:dev
  docker push 127.0.0.1:5555/api:dev
```

And install the chart by setting the component image repositories, in this example, just by the CLI

```
helm install pullsecret-test charts/self-host \
  --namespace pullsecret-test --create-namespace \
  --set "general.imagePullSecrets[0].name=registry-creds" \
  --set "general.coreVersionOverride=dev" \
  --set "component.api.image.repository=127.0.0.1:5555/bitwarden-test"

```
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
