### PR TITLE
[SHOT-52]: Add pre-commit hooks for linting and schema regeneration

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook for the Bitwarden Helm charts repo. Enable it with:
+#   git config --local core.hooksPath .git-hooks
+#
+# Requires helm and the helm-schema plugin (https://github.com/dadav/helm-schema).
+set -euo pipefail
+
+# Lint the charts.
+helm lint charts/self-host charts/sm-operator
+
+# Regenerate values.schema.json for any chart whose values.yaml is staged, then
+# re-stage it so every commit carries a schema that matches its values.yaml.
+staged_values="$(git diff --cached --name-only --diff-filter=ACM -- 'charts/*/values.yaml')"
+if [ -n "${staged_values}" ]; then
+  for chart in $(printf '%s\n' "${staged_values}" | xargs -n1 dirname | sort -u); do
+    echo "pre-commit: regenerating ${chart}/values.schema.json"
+    helm schema --chart-search-root "${chart}" -k additionalProperties --skip-auto-generation required
+    git add "${chart}/values.schema.json"
+  done
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,19 @@
 
 Our [Contributing Guidelines](https://contributing.bitwarden.com/contributing/) are located in our [Contributing Documentation](https://contributing.bitwarden.com/). The documentation also includes recommended tooling, code style tips, and lots of other great information to get you started.
 
+## Pre-Commit Hooks
+
+This repository ships git hooks in [`.git-hooks`](.git-hooks). Enable them once with:
+
+```bash
+git config --local core.hooksPath .git-hooks
+```
+
+The pre-commit hook lints the charts with `helm lint` and regenerates `values.schema.json` for any chart whose `values.yaml` is staged. It requires [Helm](https://helm.sh/) and the [helm-schema](https://github.com/dadav/helm-schema) plugin.
+
 ## Helm Schema
 
-Helm chart schemas are generated from `values.yaml` files. The CI validates that schemas are up-to-date using the Helm plugin: [helm-schema](https://github.com/dadav/helm-schema).
-
-To update schemas after making changes to a values file:
+Helm chart schemas are generated from `values.yaml` files, and validated by CI. You can regenerate manually, or use the pre-commit hook:
 
 ```bash
 helm plugin install https://github.com/dadav/helm-schema


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SHOT-52
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds pre-commit hooks with git that lints and regenerate the schema when a user makes a commit. 

Install instructions were added to CONTRIBUTING.md
https://github.com/bitwarden/helm-charts/blob/780da093b5e5a15a2e09f9fdb1544b99b1589f64/CONTRIBUTING.md#pre-commit-hooks

<img width="470" height="111" alt="image" src="https://github.com/user-attachments/assets/5582222a-3e23-4a67-8404-b9e6fdcc43f8" />


<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
