### PR TITLE
feat(self-host): expose dnsConfig/dnsPolicy on component pods

### DIFF
--- a/charts/self-host/Chart.yaml
+++ b/charts/self-host/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 - name: bitwarden
 name: self-host
 type: application
-version: 2.0.1
+version: 2.1.0

--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -59,6 +59,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.admin.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.admin.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.admin.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.admin.dnsConfig }}
+        {{ toYaml .Values.component.admin.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.admin.podServiceAccount }}
       serviceAccount: {{ .Values.component.admin.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.admin.podServiceAccount | quote }}

--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -67,6 +67,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.admin.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.admin.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.admin.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.admin.dnsConfig }}
+        {{ toYaml .Values.component.admin.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.admin.podServiceAccount }}
       serviceAccount: {{ .Values.component.admin.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.admin.podServiceAccount | quote }}

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -59,6 +59,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.api.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.api.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.api.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.api.dnsConfig }}
+        {{ toYaml .Values.component.api.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.api.podServiceAccount }}
       serviceAccount: {{ .Values.component.api.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.api.podServiceAccount | quote }}

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -67,6 +67,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.api.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.api.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.api.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.api.dnsConfig }}
+        {{ toYaml .Values.component.api.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.api.podServiceAccount }}
       serviceAccount: {{ .Values.component.api.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.api.podServiceAccount | quote }}

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -58,6 +58,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.attachments.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.attachments.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.attachments.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.attachments.dnsConfig }}
+        {{ toYaml .Values.component.attachments.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.attachments.podServiceAccount }}
       serviceAccount: {{ .Values.component.attachments.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.attachments.podServiceAccount | quote }}

--- a/charts/self-host/templates/attachments.yaml
+++ b/charts/self-host/templates/attachments.yaml
@@ -66,6 +66,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.attachments.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.attachments.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.attachments.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.attachments.dnsConfig }}
+        {{ toYaml .Values.component.attachments.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.attachments.podServiceAccount }}
       serviceAccount: {{ .Values.component.attachments.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.attachments.podServiceAccount | quote }}

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -59,6 +59,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.events.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.events.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.events.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.events.dnsConfig }}
+        {{ toYaml .Values.component.events.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.events.podServiceAccount }}
       serviceAccount: {{ .Values.component.events.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.events.podServiceAccount | quote }}

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -67,6 +67,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.events.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.events.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.events.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.events.dnsConfig }}
+        {{ toYaml .Values.component.events.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.events.podServiceAccount }}
       serviceAccount: {{ .Values.component.events.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.events.podServiceAccount | quote }}

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -58,6 +58,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.icons.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.icons.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.icons.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.icons.dnsConfig }}
+        {{ toYaml .Values.component.icons.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.icons.podServiceAccount }}
       serviceAccount: {{ .Values.component.icons.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.icons.podServiceAccount | quote }}

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -66,6 +66,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.icons.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.icons.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.icons.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.icons.dnsConfig }}
+        {{ toYaml .Values.component.icons.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.icons.podServiceAccount }}
       serviceAccount: {{ .Values.component.icons.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.icons.podServiceAccount | quote }}

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -59,6 +59,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.identity.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.identity.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.identity.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.identity.dnsConfig }}
+        {{ toYaml .Values.component.identity.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.identity.podServiceAccount }}
       serviceAccount: {{ .Values.component.identity.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.identity.podServiceAccount | quote }}

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -67,6 +67,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.identity.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.identity.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.identity.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.identity.dnsConfig }}
+        {{ toYaml .Values.component.identity.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.identity.podServiceAccount }}
       serviceAccount: {{ .Values.component.identity.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.identity.podServiceAccount | quote }}

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -58,6 +58,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.notifications.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.notifications.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.notifications.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.notifications.dnsConfig }}
+        {{ toYaml .Values.component.notifications.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.notifications.podServiceAccount }}
       serviceAccount: {{ .Values.component.notifications.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.notifications.podServiceAccount | quote }}

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -66,6 +66,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.notifications.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.notifications.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.notifications.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.notifications.dnsConfig }}
+        {{ toYaml .Values.component.notifications.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.notifications.podServiceAccount }}
       serviceAccount: {{ .Values.component.notifications.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.notifications.podServiceAccount | quote }}

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -60,6 +60,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.scim.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.scim.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.scim.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.scim.dnsConfig }}
+        {{ toYaml .Values.component.scim.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.scim.podServiceAccount }}
       serviceAccount: {{ .Values.component.scim.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.scim.podServiceAccount | quote }}

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -68,6 +68,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.scim.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.scim.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.scim.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.scim.dnsConfig }}
+        {{ toYaml .Values.component.scim.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.scim.podServiceAccount }}
       serviceAccount: {{ .Values.component.scim.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.scim.podServiceAccount | quote }}

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -59,6 +59,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.sso.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.sso.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.sso.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.sso.dnsConfig }}
+        {{ toYaml .Values.component.sso.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.sso.podServiceAccount }}
       serviceAccount: {{ .Values.component.sso.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.sso.podServiceAccount | quote }}

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -67,6 +67,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.sso.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.sso.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.sso.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.sso.dnsConfig }}
+        {{ toYaml .Values.component.sso.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.sso.podServiceAccount }}
       serviceAccount: {{ .Values.component.sso.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.sso.podServiceAccount | quote }}

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -58,6 +58,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.web.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.web.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.web.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.web.dnsConfig }}
+        {{ toYaml .Values.component.web.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.web.podServiceAccount }}
       serviceAccount: {{ .Values.component.web.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.web.podServiceAccount | quote }}

--- a/charts/self-host/templates/web.yaml
+++ b/charts/self-host/templates/web.yaml
@@ -66,6 +66,17 @@ spec:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if or .Values.component.web.dnsPolicy .Values.general.dnsPolicy }}
+      dnsPolicy: {{ default .Values.general.dnsPolicy .Values.component.web.dnsPolicy }}
+      {{- end }}
+      {{- if or .Values.component.web.dnsConfig .Values.general.dnsConfig }}
+      dnsConfig:
+        {{- if .Values.component.web.dnsConfig }}
+        {{ toYaml .Values.component.web.dnsConfig | nindent 8 }}
+        {{- else }}
+        {{ toYaml .Values.general.dnsConfig | nindent 8 }}
+        {{- end }}
+      {{- end }}
     {{- if .Values.component.web.podServiceAccount }}
       serviceAccount: {{ .Values.component.web.podServiceAccount | quote }}
       serviceAccountName: {{ .Values.component.web.podServiceAccount | quote }}

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -19,6 +19,18 @@
               "title": "deploymentStrategy",
               "type": "string"
             },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
+              "type": "string"
+            },
             "extraEnv": {
               "description": "Extra environment variables to add to the container",
               "items": {
@@ -254,6 +266,18 @@
               "default": "RollingUpdate",
               "description": "Specifies the strategy used to replace old Pods by new ones. The value can be \"Recreate\" or \"RollingUpdate\". \"RollingUpdate\" is the default value.",
               "title": "deploymentStrategy",
+              "type": "string"
+            },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
               "type": "string"
             },
             "extraEnv": {
@@ -513,6 +537,18 @@
               "title": "deploymentStrategy",
               "type": "string"
             },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
+              "type": "string"
+            },
             "extraEnv": {
               "description": "Extra environment variables to add to the container",
               "items": {
@@ -742,6 +778,18 @@
               "default": "RollingUpdate",
               "description": "Specifies the strategy used to replace old Pods by new ones. The value can be \"Recreate\" or \"RollingUpdate\". \"RollingUpdate\" is the default value.",
               "title": "deploymentStrategy",
+              "type": "string"
+            },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
               "type": "string"
             },
             "extraEnv": {
@@ -982,6 +1030,18 @@
               "title": "deploymentStrategy",
               "type": "string"
             },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
+              "type": "string"
+            },
             "extraEnv": {
               "description": "Extra environment variables to add to the container",
               "items": {
@@ -1211,6 +1271,18 @@
               "default": "RollingUpdate",
               "description": "Specifies the strategy used to replace old Pods by new ones. The value can be \"Recreate\" or \"RollingUpdate\". \"RollingUpdate\" is the default value.",
               "title": "deploymentStrategy",
+              "type": "string"
+            },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
               "type": "string"
             },
             "extraEnv": {
@@ -1470,6 +1542,18 @@
               "title": "deploymentStrategy",
               "type": "string"
             },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
+              "type": "string"
+            },
             "extraEnv": {
               "description": "Extra environment variables to add to the container",
               "items": {
@@ -1701,6 +1785,18 @@
               "title": "deploymentStrategy",
               "type": "string"
             },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
+              "type": "string"
+            },
             "enabled": {
               "default": false,
               "description": "SCIM is disabled by default.  To use this service, enable it below and set an appropriate Ingress path",
@@ -1872,6 +1968,18 @@
               "default": "RollingUpdate",
               "description": "Specifies the strategy used to replace old Pods by new ones. The value can be \"Recreate\" or \"RollingUpdate\". \"RollingUpdate\" is the default value.",
               "title": "deploymentStrategy",
+              "type": "string"
+            },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
               "type": "string"
             },
             "extraEnv": {
@@ -2124,6 +2232,18 @@
               "default": "RollingUpdate",
               "description": "Specifies the strategy used to replace old Pods by new ones. The value can be \"Recreate\" or \"RollingUpdate\". \"RollingUpdate\" is the default value.",
               "title": "deploymentStrategy",
+              "type": "string"
+            },
+            "dnsConfig": {
+              "default": {},
+              "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+              "title": "dnsConfig",
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "default": "",
+              "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+              "title": "dnsPolicy",
               "type": "string"
             },
             "extraEnv": {
@@ -2638,6 +2758,18 @@
           "required": [],
           "title": "distributedCache",
           "type": "object"
+        },
+        "dnsConfig": {
+          "default": {},
+          "description": "Pod spec.dnsConfig. Use on clusters where the default ndots:5 plus corporate DNS search domains break outbound resolution from the Alpine/musl images (e.g. set options ndots:\"2\"). Override per component under component.<name>.dnsConfig.",
+          "title": "dnsConfig",
+          "type": "object"
+        },
+        "dnsPolicy": {
+          "default": "",
+          "description": "Pod DNS policy. Empty uses the Kubernetes default (ClusterFirst). Override per component under component.<name>.dnsPolicy.",
+          "title": "dnsPolicy",
+          "type": "string"
         },
         "domain": {
           "default": "REPLACE",

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -2710,6 +2710,18 @@
           "title": "distributedCache",
           "type": "object"
         },
+        "dnsConfig": {
+          "description": "Pod DNS config for all components, mapped to a Pod's spec.dnsConfig (override per component).\nUse on clusters where the kubelet default ndots:5 plus corporate search domains break outbound\nresolution from the Alpine/musl images. Example: options ndots \"2\".",
+          "required": [],
+          "title": "dnsConfig",
+          "type": "object"
+        },
+        "dnsPolicy": {
+          "default": "",
+          "description": "Pod DNS policy for all components (override per component under component.\u003cname\u003e.dnsPolicy).\nEmpty uses the Kubernetes default (ClusterFirst).",
+          "title": "dnsPolicy",
+          "type": "string"
+        },
         "domain": {
           "default": "REPLACE",
           "description": "Domain name for the service",

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -138,6 +138,18 @@ general:
     enforceSsoPolicyForAllUsers: false
   # Custom labels to add throughout the installation
   labels: {}
+  # Pod DNS policy for all components (override per component under component.<name>.dnsPolicy).
+  # Empty = Kubernetes default ("ClusterFirst").
+  dnsPolicy: ""
+  # Pod DNS config for all components, mapped to a Pod's spec.dnsConfig (override per component).
+  # Needed where the kubelet default ndots:5 + corporate DNS search domains break outbound
+  # resolution from the Alpine/musl images (e.g. license/billing sync to identity.bitwarden.eu
+  # failing "Name does not resolve" while nslookup/curl succeed). Example:
+  #   dnsConfig:
+  #     options:
+  #       - name: ndots
+  #         value: "2"
+  dnsConfig: {}
   # Custom annotations to add throughout the installation
   annotations: {}
   # Additional default pod labels

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -138,6 +138,13 @@ general:
     enforceSsoPolicyForAllUsers: false
   # Custom labels to add throughout the installation
   labels: {}
+  # Pod DNS policy for all components (override per component under component.<name>.dnsPolicy).
+  # Empty uses the Kubernetes default (ClusterFirst).
+  dnsPolicy: ""
+  # Pod DNS config for all components, mapped to a Pod's spec.dnsConfig (override per component).
+  # Use on clusters where the kubelet default ndots:5 plus corporate search domains break outbound
+  # resolution from the Alpine/musl images. Example: options ndots "2".
+  dnsConfig: {}
   # Custom annotations to add throughout the installation
   annotations: {}
   # Additional default pod labels


### PR DESCRIPTION
## Problem

On clusters where the kubelet injects the default `options ndots:5` and the pod inherits corporate DNS search domains, automatic licensing/billing sync fails. The 2-dot cloud endpoints (`identity.bitwarden.eu`, `api.bitwarden.eu`, `selfhost.bitwarden.com`) get search-expanded first; when the corporate resolver returns **SERVFAIL** for the bogus expanded name (e.g. `identity.bitwarden.eu.corp.example`), the Alpine/**musl** `getaddrinfo` in our images aborts the entire lookup and never tries the real name. .NET surfaces it as `SocketException 0xFFFDFFFF "Name does not resolve"`; `nslookup`/`curl` use a different resolver path and succeed, which makes it hard to diagnose. glibc does not abort on SERVFAIL during search — this is musl-specific and by design.

## Why a chart change

The fix is a standard Pod `dnsConfig` (`options: ndots:2`), but the chart exposes **no `dnsConfig`/`dnsPolicy` field**. The only workaround is an out-of-band `kubectl patch`, which `helm upgrade` overwrites.

## Change

Adds `general.dnsPolicy` / `general.dnsConfig` with per-component overrides under `component.<name>`, rendered into each component Deployment's pod spec — same override pattern as `nodeSelector`/`tolerations`. Includes `values.schema.json` entries and bumps the chart `2.0.1 -> 2.1.0` (`appVersion` unchanged).

Result:

```yaml
general:
  dnsConfig:
    options:
      - name: ndots
        value: "2"
```

Upgrade-safe, supported value instead of a manual patch.

## Test plan

- `helm template` with and without `general.dnsConfig` → block present/absent in each Deployment.
- Per-component override beats `general`.
- `helm lint` passes with the schema entries (validated).
- Repro: cluster with `ndots:5` + a search domain whose resolver SERVFAILs the expanded name → `getent hosts identity.bitwarden.eu` empty before, resolves after setting `ndots:2`.

## Root-cause references

- musl `src/network/lookup_name.c` — `name_from_dns` returns `EAI_AGAIN` on SERVFAIL (rcode 2), `0` on NXDOMAIN (rcode 3); `name_from_dns_search` aborts on the non-zero return.
- dotnet/runtime `src/native/libs/System.Native/pal_networking.c` — `SystemNative_GetHostEntryForName` calls libc `getaddrinfo` directly.
- Kubernetes DNS docs — `options ndots:5` default; `dnsConfig.options` "merged to the options generated from the specified DNS policy. Duplicate entries are removed."