### PR TITLE
Extend securityContext

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -77,6 +77,8 @@ spec:
           mkdir -p /logs/admin
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.admin.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -77,6 +77,8 @@ spec:
           mkdir -p /logs/api
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.api.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -77,6 +77,8 @@ spec:
           mkdir -p /logs/events
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.events.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -76,6 +76,8 @@ spec:
           mkdir -p /logs/icons
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.icons.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -77,6 +77,8 @@ spec:
           mkdir -p /logs/identity
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.identity.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -76,6 +76,8 @@ spec:
           mkdir -p /logs/notifications
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.notifications.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/pre-install-secret-sql.yaml
+++ b/charts/self-host/templates/pre-install-secret-sql.yaml
@@ -51,6 +51,10 @@ spec:
     {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name | quote }}
     {{- end }}
+    {{- if .Values.jobs.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.jobs.podSecurityContext | nindent 8 }}
+    {{- end }}
       containers:
       - name: create-resources
         command:
@@ -63,6 +67,10 @@ spec:
           echo "Done"
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        {{- if .Values.jobs.securityContext }}
+        securityContext:
+          {{- toYaml .Values.jobs.securityContext | nindent 10 }}
+        {{- end }}
         {{- if .Values.jobs.secret.resources }}
         resources:
           {{- toYaml .Values.jobs.secret.resources | nindent 10 }}

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -78,6 +78,8 @@ spec:
           mkdir -p /logs/scim
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.scim.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -77,6 +77,8 @@ spec:
           mkdir -p /logs/sso
         ']
         image: "{{ .Values.supportComponents.kubectl.image.repository }}:{{ .Values.supportComponents.kubectl.image.tag }}"
+        securityContext:
+{{ toYaml .Values.component.sso.securityContext | indent 10 }}
         volumeMounts:
           - name: applogs
             mountPath: /logs

--- a/charts/self-host/tests/security_context_test.yaml
+++ b/charts/self-host/tests/security_context_test.yaml
@@ -1,0 +1,155 @@
+suite: test securityContext on init containers and the pre-install-secret-sql job
+templates:
+  - templates/helpers.tpl
+  - templates/admin.yaml
+  - templates/api.yaml
+  - templates/events.yaml
+  - templates/icons.yaml
+  - templates/identity.yaml
+  - templates/notifications.yaml
+  - templates/scim.yaml
+  - templates/sso.yaml
+  - templates/pre-install-secret-sql.yaml
+
+tests:
+  # admin
+  - it: admin - should render securityContext on the create-mount-subdir init container
+    template: templates/admin.yaml
+    set:
+      volume.logs.enabled: true
+      component.admin.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: create-mount-subdir
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  - it: admin - should render an empty securityContext on the init container by default
+    template: templates/admin.yaml
+    set:
+      volume.logs.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext
+          value: {}
+        documentIndex: 0
+
+  # api
+  - it: api - should render securityContext on the create-mount-subdir init container
+    template: templates/api.yaml
+    set:
+      volume.logs.enabled: true
+      component.api.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # events
+  - it: events - should render securityContext on the create-mount-subdir init container
+    template: templates/events.yaml
+    set:
+      volume.logs.enabled: true
+      component.events.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # icons
+  - it: icons - should render securityContext on the create-mount-subdir init container
+    template: templates/icons.yaml
+    set:
+      volume.logs.enabled: true
+      component.icons.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # identity
+  - it: identity - should render securityContext on the create-mount-subdir init container
+    template: templates/identity.yaml
+    set:
+      volume.logs.enabled: true
+      component.identity.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # notifications
+  - it: notifications - should render securityContext on the create-mount-subdir init container
+    template: templates/notifications.yaml
+    set:
+      volume.logs.enabled: true
+      component.notifications.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # scim
+  - it: scim - should render securityContext on the create-mount-subdir init container
+    template: templates/scim.yaml
+    set:
+      component.scim.enabled: true
+      volume.logs.enabled: true
+      component.scim.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # sso
+  - it: sso - should render securityContext on the create-mount-subdir init container
+    template: templates/sso.yaml
+    set:
+      volume.logs.enabled: true
+      component.sso.securityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  # pre-install-secret-sql job
+  - it: secret-sql - should render pod securityContext from jobs.podSecurityContext
+    template: templates/pre-install-secret-sql.yaml
+    set:
+      jobs.podSecurityContext.runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+        documentIndex: 0
+
+  - it: secret-sql - should render container securityContext from jobs.securityContext
+    template: templates/pre-install-secret-sql.yaml
+    set:
+      jobs.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+        documentIndex: 0
+
+  - it: secret-sql - should not render securityContext blocks when unset
+    template: templates/pre-install-secret-sql.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.securityContext
+        documentIndex: 0
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext
+        documentIndex: 0


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SHOT-165
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Extends the securityContext configuration to also be applied to initcontainers for job and deployment templates. 

## 🔧  Usage
securityContext will now render for normal and init containers for deployments using `component.<name>.securityContext`.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
