### PR TITLE
charts/self-host: replace ghcr.io/bitwarden/mssql with mcr.microsoft.com/mssql/server

### DIFF
--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -68,7 +68,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "bitwarden.mssql" . }}
-          image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"
+          image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag | default .Values.general.coreVersionOverride | default (include "bitwarden.coreVersionDefault" nil) }}"
           imagePullPolicy: Always
           {{- if .Values.database.resources }}
           resources:

--- a/charts/self-host/tests/component_image_test.yaml
+++ b/charts/self-host/tests/component_image_test.yaml
@@ -26,7 +26,7 @@ tests:
     template: templates/api.yaml
     set:
       component.api.image.tag: "2025.12.0"
-      general.coreVersionOverride: "2025.12.0"
+      general.coreVersionOverride: "2025.11.0"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -73,14 +73,44 @@ tests:
           path: kind
           value: Deployment
 
-  - it: should use database tag defaults
+  - it: should use global coreVersionOverride when database tag is empty for database
     template: templates/mssql.yaml
     set:
       database.enabled: true
+      database.image.tag: ""
+      general.coreVersionOverride: "2025.12.0"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04"
+          value: "ghcr.io/bitwarden/mssql:2025.12.0"
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: should use component-specific tag for database when set (overrides coreVersionOverride)
+    template: templates/mssql.yaml
+    set:
+      database.enabled: true
+      database.image.tag: "2025.12.0"
+      general.coreVersionOverride: "2025.11.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/bitwarden/mssql:2025.12.0"
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: should use custom repository when set for database
+    template: templates/mssql.yaml
+    set:
+      database.enabled: true
+      database.image.repository: "custom.com/bitwarden/mssql"
+      general.coreVersionOverride: "2025.12.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "custom.com/bitwarden/mssql:2025.12.0"
         documentSelector:
           path: kind
           value: StatefulSet

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -2368,12 +2368,12 @@
           "description": "Image repository, tag, and pull policy",
           "properties": {
             "repository": {
-              "default": "mcr.microsoft.com/mssql/server",
+              "default": "ghcr.io/bitwarden/mssql",
               "title": "repository",
               "type": "string"
             },
             "tag": {
-              "default": "2022-CU22-ubuntu-22.04",
+              "default": "",
               "title": "tag",
               "type": "string"
             }

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -978,8 +978,8 @@ database:
   tolerations: []
   # Image repository, tag, and pull policy
   image:
-    repository: mcr.microsoft.com/mssql/server
-    tag: 2022-CU22-ubuntu-22.04
+    repository: ghcr.io/bitwarden/mssql
+    tag: ""
   # The container is limited to the resources below.  Adjust for your environment.
   resources:
     requests:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The current mssql image used is relatively old and bitwarden already provides a perfectly good mssql server image. In my tests it was a 1 to 1 replacement, no additional setup or changes needed.