### PR TITLE
[BRE-2044] Update CODEOWNERS for Self-Host Helm Chart Release process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 
 ## These specific files are shared and are used in releases ##
 **/Chart.yaml
+charts/self-host/templates/helpers.tpl
 
 ## BRE team owns these workflows ##
 .github/workflows/release.yml @bitwarden/dept-bre


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2044](https://bitwarden.atlassian.net/browse/BRE-2044)

## 📔 Objective

Update CODEOWNERS for Self-Host Helm Chart Release process

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-2044]: https://bitwarden.atlassian.net/browse/BRE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ