### PR TITLE
[SHOT-82] ci: Cancel CD runs for version:skip merges

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,7 @@ jobs:
     name: Detect release
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: read
       pull-requests: read
     outputs:
@@ -52,6 +53,21 @@ jobs:
           CHARTS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files \
             --jq '[.files[].path | select(startswith("charts/")) | split("/")[1]] | map(select(. == "self-host" or . == "sm-operator")) | unique')
           echo "charts=$CHARTS" >> "$GITHUB_OUTPUT"
+
+      # A skip (version:skip label) is a normal no-op, not a release. Cancel the run so it
+      # reads as "cancelled" rather than a green success that implies a release happened.
+      - name: Cancel run when nothing to release
+        if: steps.bump.outputs.type == 'skip'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "No release needed — cancelling this run so it isn't marked successful." | tee -a "$GITHUB_STEP_SUMMARY"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel"
+          # Block until the cancellation lands so the run finalizes as "cancelled". If it never
+          # takes effect, fail rather than silently reporting success.
+          for _ in $(seq 1 60); do sleep 5; done
+          echo "::error::Cancellation did not take effect within 5 minutes."
+          exit 1
 
   version-bump:
     name: Version bump (${{ matrix.chart }})


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SHOT-82

## 📔 Objective

Follow-up to #562 (label-driven CD). Adds a "Cancel run when nothing to release" step to `cd.yml`'s `detect` job so a `version:skip` merge cancels its CD run instead of finishing as a green success that implies a release happened. Ports the cancel-skip pattern from bitwarden/workflow-linter (#248/#259).
