### PR TITLE
[SHOT-240] ci: Use the chart's kubectl image in chart-testing values

### DIFF
--- a/charts/self-host/ci/test-gateway-values.yaml
+++ b/charts/self-host/ci/test-gateway-values.yaml
@@ -207,10 +207,6 @@ supportComponents:
     image:
       repository: alpine/openssl
       tag: 3.5.2
-  kubectl:
-    image:
-      repository: ghcr.io/bitwarden/helm-charts/kubectl
-      tag: 1.34
 # Data volume sizes for shared PVCs
 volume:
   dataprotection:

--- a/charts/self-host/ci/test-values.yaml
+++ b/charts/self-host/ci/test-values.yaml
@@ -252,10 +252,6 @@ supportComponents:
     image:
       repository: alpine/openssl
       tag: 3.5.2
-  kubectl:
-    image:
-      repository: ghcr.io/bitwarden/helm-charts/kubectl
-      tag: 1.34
 # Data volume sizes for shared PVCs
 volume:
   dataprotection:


### PR DESCRIPTION
## 🎟️ Tracking

- [SHOT-240](https://bitwarden.atlassian.net/browse/SHOT-240)
- [VULN-726](https://bitwarden.atlassian.net/browse/VULN-726)

## 📔 Objective

PR #490 moved the self-host chart off `ghcr.io/bitwarden/helm-charts/kubectl` (the image flagged in VULN-726) to `alpine/kubectl`, but the chart-testing values files were never updated and still overrode it back to `ghcr.io/bitwarden/helm-charts/kubectl:1.34`.

That override was live, not cosmetic. The Kind e2e installs the chart with those exact files (`scripts/setup.sh:179-183`, driven by `self-host.yml`), and the kubepug job templates every `charts/self-host/ci/*.yaml` — so CI was still pulling the retired image on every run.

This removes the `supportComponents.kubectl` block from both CI values files so chart-testing inherits the chart default (`alpine/kubectl:1.36.2`).

**Why delete rather than re-pin to `alpine/kubectl:1.36.2`:** Renovate's `helm-values` manager covers `values.yaml` but not `ci/*.yaml`, so an explicit pin would drift again on the next bump — which is exactly how we got here. Inheriting the default keeps CI on whatever the chart actually ships.

No `values.yaml` change, so no `helm schema` regeneration and no `values.schema.json` diff. Templates and unit tests are untouched — `component_image_test.yaml` already asserts `alpine/kubectl`.

### Verification

- `grep -rn "helm-charts/kubectl" charts/` — no matches
- Both CI value sets render `image: "alpine/kubectl:1.36.2"` and nothing else for kubectl
- `helm unittest charts/self-host` — 135 tests / 15 suites pass
- `helm lint` clean against both value sets
- `test-self-host-kind` runs `ingress` and `gateway` on this PR, which is the real end-to-end check that the image pulls and the init containers, pre-install secret jobs, and `wait-for-db` still work

### Follow-up (not in this PR)

`certGenerator` in the same two files still pins `alpine/openssl:3.5.2` while the chart is on `3.5.7` — same root cause, worth its own ticket.

[SHOT-240]: https://bitwarden.atlassian.net/browse/SHOT-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-726]: https://bitwarden.atlassian.net/browse/VULN-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ