### PR TITLE
[SHOT-230] (feat SH): Make the MSSQL startup probe timing configurable

### DIFF
--- a/charts/self-host/templates/mssql.yaml
+++ b/charts/self-host/templates/mssql.yaml
@@ -122,9 +122,12 @@ spec:
                 - '/bin/sh'
                 - '-c'
                 - 'if [ -x /opt/mssql-tools18/bin/sqlcmd ]; then /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "${SA_PASSWORD}" -Q "SELECT 1" || exit 1; else /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -Q "SELECT 1" || exit 1; fi'
-            initialDelaySeconds: 120
-            periodSeconds: 10
-            timeoutSeconds: 3
+            {{- with .Values.database.startupProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ . }}
+            {{- end }}
+            periodSeconds: {{ .Values.database.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.database.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.database.startupProbe.failureThreshold }}
           {{- if .Values.database.securityContext }}
           securityContext:
 {{ toYaml .Values.database.securityContext | indent 12 }}

--- a/charts/self-host/tests/probe_timing_test.yaml
+++ b/charts/self-host/tests/probe_timing_test.yaml
@@ -1,0 +1,79 @@
+suite: test probe timing on the startup critical path
+templates:
+  - templates/*.tpl
+  - templates/mssql.yaml
+tests:
+  - it: should gate MSSQL startup on a polled budget rather than a fixed delay
+    template: templates/mssql.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 3
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 60
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: should keep the MSSQL startup probe an exec sqlcmd check
+    template: templates/mssql.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          pattern: sqlcmd .*-Q "SELECT 1"
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: should allow operators to widen the MSSQL startup budget
+    template: templates/mssql.yaml
+    set:
+      database.startupProbe.periodSeconds: 10
+      database.startupProbe.failureThreshold: 90
+      database.startupProbe.timeoutSeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 90
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 5
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: should render an MSSQL startup delay only when one is set
+    template: templates/mssql.yaml
+    set:
+      database.startupProbe.initialDelaySeconds: 45
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 45
+        documentSelector:
+          path: kind
+          value: StatefulSet

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -2531,6 +2531,29 @@
           "title": "securityContext",
           "type": "object"
         },
+        "startupProbe": {
+          "description": "Startup probe timing.  The startup budget is periodSeconds * failureThreshold; raise failureThreshold for slow storage.",
+          "properties": {
+            "failureThreshold": {
+              "default": 60,
+              "title": "failureThreshold",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "default": 5,
+              "title": "periodSeconds",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "default": 3,
+              "title": "timeoutSeconds",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "startupProbe",
+          "type": "object"
+        },
         "tolerations": {
           "description": "Optionally add taint tolerations",
           "items": {

--- a/charts/self-host/values.schema.json
+++ b/charts/self-host/values.schema.json
@@ -2532,7 +2532,7 @@
           "type": "object"
         },
         "startupProbe": {
-          "description": "Startup probe timing.  The startup budget is periodSeconds * failureThreshold; raise failureThreshold for slow storage.",
+          "description": "Startup probe timing.  The startup budget is periodSeconds * failureThreshold; raise failureThreshold for slow storage.\nSet initialDelaySeconds to hold off the first check; unset by default so the probe starts polling immediately.",
           "properties": {
             "failureThreshold": {
               "default": 60,

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -1010,6 +1010,11 @@ database:
     limits:
       memory: "2G"
       cpu: "500m"
+  # Startup probe timing.  The startup budget is periodSeconds * failureThreshold; raise failureThreshold for slow storage.
+  startupProbe:
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 60
 
   # The MSSQL volumes for the PVCs
   volume:

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -1011,6 +1011,7 @@ database:
       memory: "2G"
       cpu: "500m"
   # Startup probe timing.  The startup budget is periodSeconds * failureThreshold; raise failureThreshold for slow storage.
+  # Set initialDelaySeconds to hold off the first check; unset by default so the probe starts polling immediately.
   startupProbe:
     periodSeconds: 5
     timeoutSeconds: 3


### PR DESCRIPTION
## 🎟️ Tracking

- [SHOT-230](https://bitwarden.atlassian.net/browse/SHOT-230)

## 📔 Objective

The MSSQL `startupProbe` hardcoded `initialDelaySeconds: 120`, so every install sat for two minutes before the first `sqlcmd` check, whether or not SQL Server was already listening. MSSQL readiness is serial ahead of the DB migrator and every backend pod.

This drops the fixed delay and polls every 5s with a `failureThreshold` of 60. A `startupProbe` suspends the liveness and readiness probes until it first succeeds, so the pod is still gated on a real `SELECT 1` rather than on a timer.

The startup budget also widens. Old behavior was 120s of delay plus 10s × the default threshold of 3, or 150s. New behavior is 5s × 60, or 300s, which gives slow storage more room than the fixed delay did.

All four fields now live under `database.startupProbe`. `initialDelaySeconds` is unset by default and only renders when an operator sets one, so the old shape is still reachable.

### Verification

- Kind e2e install step: 200-252s on main, 136s/114s with this change
- `helm unittest charts/self-host`: 139 tests across 16 suites, including a new `probe_timing_test.yaml`
- `ct lint --charts charts/self-host`: clean against both CI value sets
- `values.schema.json` regenerated with `helm schema`, no diff


[SHOT-230]: https://bitwarden.atlassian.net/browse/SHOT-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ