### PR TITLE
[BRE-2116] Add allow-unsafe-pr-checkout to helm-charts pull_request_target builds

### DIFF
--- a/.github/workflows/self-host.yml
+++ b/.github/workflows/self-host.yml
@@ -62,6 +62,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Helm
         uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/sm-operator.yml
+++ b/.github/workflows/sm-operator.yml
@@ -58,6 +58,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Helm
         uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2116

## 📔 Objective

Adds `allow-unsafe-pr-checkout: true` to the fork-checkout steps in `self-host.yml` and `sm-operator.yml` (both already on checkout `v7.0.1`).

These workflows run via `target.yml` (`pull_request_target`) and check out fork `head.sha` to run kind/chart tests. checkout v7 refuses that fork checkout by default; without this flag the fork-PR test path is broken.

Regression-prevention only — this preserves existing behavior and does NOT remediate the underlying pwn-request exposure (fork code running in a privileged context). Remediation is scoped in the follow-up spike.
