### PR TITLE
ci: Pass the resolved build run ID to the release trigger

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,6 +124,8 @@ jobs:
     permissions:
       actions: read # read build-workflow run status
       contents: read
+    outputs:
+      build_run_id: ${{ steps.wait.outputs.run_id }}
     strategy:
       fail-fast: false
       matrix:
@@ -137,6 +139,7 @@ jobs:
           persist-credentials: false
 
       - name: Wait for chart build
+        id: wait
         env:
           GH_TOKEN: ${{ github.token }}
           CHART: ${{ matrix.chart }}
@@ -174,6 +177,8 @@ jobs:
           echo "Watching build run $run_id for $CHART $expected..."
           gh run watch "$run_id" --exit-status --interval 30
 
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
   release:
     name: Release charts
     needs: wait-for-build
@@ -188,3 +193,4 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           task: release-helm-charts
+          data: '{"build_run_id": "${{ needs.wait-for-build.outputs.build_run_id }}"}'


### PR DESCRIPTION
## Tracking

https://bitwarden.atlassian.net/browse/SHOT-250. Follow-up to the 2.2.0 release that published nothing on 2026-08-10.

## Objective

The `release` job triggers deploy's `release-helm-charts` with no payload, so deploy picks the chart package itself using "newest successful self-host.yml build on main". On 2026-08-10 GitHub served that listing stale and returned a June 23 run holding self-host 2.0.1. `cr upload` skipped it as already released, `cr index` reported no change, and every job went green. 2.2.0 is on main but was never published.

`wait-for-build` already resolves the run that packaged the bumped version, then throws the ID away. This passes it through so deploy publishes that exact artifact.

Four lines: a job output, an `id` on the existing step, one `$GITHUB_OUTPUT` write, and the `data:` payload.

Two things to know:

1. Deploy needs a matching `build_run_id` input before this merges. `workflow_dispatch` rejects inputs it doesn't declare, so the trigger would fail outright.
2. Matrix legs share one output name and last writer wins, so a PR bumping both charts pins whichever leg finished last. Single-chart bumps, which is every release this year, are correct.
