### PR TITLE
[SHOT-233] fix: Mount caCertificates in the DB migrator jobs

### DIFF
--- a/charts/self-host/templates/post-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/post-install-db-migrator-job.yaml
@@ -127,6 +127,10 @@ spec:
         volumeMounts:
         - name: migrator-extract-dir
           mountPath: "/migrator"
+        {{- if .Values.volume.caCertificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -146,6 +150,11 @@ spec:
         - name: mssql-data
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.mssqlData" . ) .Values.database.volume.data.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.caCertificates.enabled }}
+        - name: ca-certificates
+          configMap:
+            name: {{ .Values.volume.caCertificates.configMapName }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/pre-install-db-migrator-job.yaml
+++ b/charts/self-host/templates/pre-install-db-migrator-job.yaml
@@ -89,6 +89,10 @@ spec:
         volumeMounts:
         - name: migrator-extract-dir
           mountPath: "/migrator"
+        {{- if .Values.volume.caCertificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -101,6 +105,11 @@ spec:
       volumes:
         - name: migrator-extract-dir
           emptyDir: {}
+        {{- if .Values.volume.caCertificates.enabled }}
+        - name: ca-certificates
+          configMap:
+            name: {{ .Values.volume.caCertificates.configMapName }}
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           csi:

--- a/charts/self-host/tests/ca_certificates_test.yaml
+++ b/charts/self-host/tests/ca_certificates_test.yaml
@@ -34,6 +34,12 @@ tests:
             name: ca-certificates
             mountPath: /etc/bitwarden/ca-certificates
         documentIndex: 0
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+          any: true
+        documentIndex: 0
 
   - it: post-install-db-migrator-job - should mount the CA bundle when enabled
     template: templates/post-install-db-migrator-job.yaml
@@ -63,4 +69,10 @@ tests:
           content:
             name: ca-certificates
             mountPath: /etc/bitwarden/ca-certificates
+        documentIndex: 0
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+          any: true
         documentIndex: 0

--- a/charts/self-host/tests/ca_certificates_test.yaml
+++ b/charts/self-host/tests/ca_certificates_test.yaml
@@ -1,0 +1,66 @@
+suite: test caCertificates volume and mount on the DB migrator jobs
+templates:
+  - templates/helpers.tpl
+  - templates/pre-install-db-migrator-job.yaml
+  - templates/post-install-db-migrator-job.yaml
+
+tests:
+  - it: pre-install-db-migrator-job - should mount the CA bundle when enabled
+    template: templates/pre-install-db-migrator-job.yaml
+    set:
+      volume.caCertificates.enabled: true
+      volume.caCertificates.configMapName: custom-ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certificates
+            mountPath: /etc/bitwarden/ca-certificates
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            configMap:
+              name: custom-ca-bundle
+        documentIndex: 0
+
+  - it: pre-install-db-migrator-job - should not mount the CA bundle when disabled
+    template: templates/pre-install-db-migrator-job.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certificates
+            mountPath: /etc/bitwarden/ca-certificates
+        documentIndex: 0
+
+  - it: post-install-db-migrator-job - should mount the CA bundle when enabled
+    template: templates/post-install-db-migrator-job.yaml
+    set:
+      volume.caCertificates.enabled: true
+      volume.caCertificates.configMapName: custom-ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certificates
+            mountPath: /etc/bitwarden/ca-certificates
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            configMap:
+              name: custom-ca-bundle
+        documentIndex: 0
+
+  - it: post-install-db-migrator-job - should not mount the CA bundle when disabled
+    template: templates/post-install-db-migrator-job.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certificates
+            mountPath: /etc/bitwarden/ca-certificates
+        documentIndex: 0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SHOT-233

## 📔 Objective

The service deployments conditionally mount a custom CA bundle at `/etc/bitwarden/ca-certificates` under `volume.caCertificates.enabled`. Both DB migrator Jobs omitted that block.

Against an external MSSQL whose certificate is signed by a private CA, with `Encrypt=True; Trust Server Certificate=false`, the migrator pods fail pre-login chain validation:

> Certificate failed chain validation. Error(s): 'unable to get local issuer certificate, [Status: PartialChain]'

Service pods connect fine; only the two Jobs fail.

`MsSqlMigratorUtility/Dockerfile` sets `ENV SSL_CERT_DIR=/etc/bitwarden/ca-certificates`, matching `src/Api/Dockerfile`, so mounting the ConfigMap there is what makes the private CA trusted. This adds the identical guarded volume and volumeMount to both Jobs.

`wait-for-db` is deliberately left alone: it runs kubectl against the Kubernetes API and trusts the service account's in-cluster `ca.crt`.

`MSSQL_CONN_STRING` is consumed by exactly these two pods, so the fix is complete. The other hooks only run openssl/kubectl and never dial the database.

Behind an existing default-false flag, so nothing changes for users who have not opted in. Postgres is unaffected. No `values.yaml` change, so no schema regeneration.

Adds `tests/ca_certificates_test.yaml`, mutation-tested: making either the volume or the mount unconditional fails the suite.
