### PR TITLE
Add names to HTTPRoute rules

### DIFF
--- a/charts/self-host/README.md
+++ b/charts/self-host/README.md
@@ -619,6 +619,7 @@ Gateway API (`gateway.networking.k8s.io/v1`) is recommended to use, opposed to t
 
 ### Prerequisites
 
+- Gateway API CRDs v1.4.0 or later installed in the cluster.
 - A Gateway API controller installed in the cluster (e.g. Istio, Envoy Gateway, Contour, NGINX Gateway Fabric).
 - A `Gateway` resource you manage that listens for traffic on your Bitwarden domain.
 

--- a/charts/self-host/templates/httproute.yaml
+++ b/charts/self-host/templates/httproute.yaml
@@ -34,7 +34,8 @@ spec:
   hostnames:
     - {{ .Values.general.domain }}
   rules:
-    - matches:
+    - name: attachments
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.attachments.path }}
@@ -47,7 +48,8 @@ spec:
       backendRefs:
         - name: {{ template "bitwarden.attachments" . }}
           port: 5000
-    - matches:
+    - name: api
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.api.path }}
@@ -60,7 +62,8 @@ spec:
       backendRefs:
         - name: {{ template "bitwarden.api" . }}
           port: 5000
-    - matches:
+    - name: icons
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.icons.path }}
@@ -73,7 +76,8 @@ spec:
       backendRefs:
         - name: {{ template "bitwarden.icons" . }}
           port: 5000
-    - matches:
+    - name: notifications
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.notifications.path }}
@@ -86,7 +90,8 @@ spec:
       backendRefs:
         - name: {{ template "bitwarden.notifications" . }}
           port: 5000
-    - matches:
+    - name: events
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.events.path }}
@@ -100,7 +105,8 @@ spec:
         - name: {{ template "bitwarden.events" . }}
           port: 5000
     {{- if .Values.component.scim.enabled }}
-    - matches:
+    - name: scim
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.scim.path }}
@@ -114,28 +120,32 @@ spec:
         - name: {{ template "bitwarden.scim" . }}
           port: 5000
     {{- end }}
-    - matches:
+    - name: sso
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.sso.path }}
       backendRefs:
         - name: {{ template "bitwarden.sso" . }}
           port: 5000
-    - matches:
+    - name: identity
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.identity.path }}
       backendRefs:
         - name: {{ template "bitwarden.identity" . }}
           port: 5000
-    - matches:
+    - name: admin
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.admin.path }}
       backendRefs:
         - name: {{ template "bitwarden.admin" . }}
           port: 5000
-    - matches:
+    - name: web
+      matches:
         - path:
             type: PathPrefix
             value: {{ .Values.general.gateway.paths.web.path }}

--- a/charts/self-host/tests/httproute_test.yaml
+++ b/charts/self-host/tests/httproute_test.yaml
@@ -96,6 +96,58 @@ tests:
           path: spec.rules[8].matches[0].path.value
           value: /
 
+  - it: should name every rule so policies can target them by sectionName
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].name
+          value: attachments
+      - equal:
+          path: spec.rules[1].name
+          value: api
+      - equal:
+          path: spec.rules[2].name
+          value: icons
+      - equal:
+          path: spec.rules[3].name
+          value: notifications
+      - equal:
+          path: spec.rules[4].name
+          value: events
+      - equal:
+          path: spec.rules[5].name
+          value: sso
+      - equal:
+          path: spec.rules[6].name
+          value: identity
+      - equal:
+          path: spec.rules[7].name
+          value: admin
+      - equal:
+          path: spec.rules[8].name
+          value: web
+
+  - it: should name the scim rule when SCIM is enabled
+    template: templates/httproute.yaml
+    set:
+      general.gateway.enabled: true
+      general.domain: bitwarden.example.com
+      general.gateway.parentRefs:
+        - name: my-gateway
+      component.scim.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[5].name
+          value: scim
+      - equal:
+          path: spec.rules[9].name
+          value: web
+
   - it: should apply custom annotations
     template: templates/httproute.yaml
     set:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-GATEWAY_API_VERSION="v1.3.0"   # standard channel CRDs — confirm against NGF 2.6.x supported version
+GATEWAY_API_VERSION="v1.4.0"   # standard channel CRDs — confirm against NGF 2.6.x supported version
 NGF_CHART_VERSION="2.6.3"      # oci://ghcr.io/nginx/charts/nginx-gateway-fabric
 
 function createKindCluster() {


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #586

## 📔 Objective

Adds names to the `HTTPRoute` rules. This is necessary to attach a `SecurityPolicy` to lock down a specific route like `/admin` by naming the rule by `sectionName`.

Also bump Gateway API version to 1.4.0 since rule names came into the standard Gateway API in that version.